### PR TITLE
Sync to AYON logs not found project on ftrack

### DIFF
--- a/services/processor/processor/default_handlers/event_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_sync_from_ftrack.py
@@ -1574,6 +1574,12 @@ class AutoSyncFromFtrack(BaseEventHandler):
                     selection=selection
                 )
 
+        if sync_process.ft_project is None:
+            self.log.warning(
+                f"Project was not found. Skipping."
+                "\nEvent data: {event['data']}\n"
+            )
+
         if not sync_process.is_event_valid:
             self.log.debug(
                 f"Project has disabled autosync {sync_process.project_name}."


### PR DESCRIPTION
## Description
Sync sometimes crashes becase could not query ftrack project by name. This PR is not fixing the issue, just adds option to get more information why the issue happens by logging event data when issue happens.