### PR TITLE
Run user event server with headless argument

### DIFF
--- a/client/ayon_ftrack/tray/ftrack_tray.py
+++ b/client/ayon_ftrack/tray/ftrack_tray.py
@@ -178,7 +178,10 @@ class FtrackTrayWrapper:
             if self.thread_socket_server is None:
                 if failed_count < max_fail_count:
                     self.thread_socket_server = SocketThread(
-                        thread_name, thread_port, subprocess_path
+                        thread_name,
+                        thread_port,
+                        subprocess_path,
+                        ["--headless"],
                     )
                     self.thread_socket_server.start()
                     self.bool_action_thread_running = True

--- a/client/ayon_ftrack/tray/user_server.py
+++ b/client/ayon_ftrack/tray/user_server.py
@@ -235,8 +235,10 @@ class SocketThread(threading.Thread):
 
     MAX_TIMEOUT = int(os.environ.get("OPENPYPE_FTRACK_SOCKET_TIMEOUT", 45))
 
-    def __init__(self, name, port, filepath, additional_args=[]):
+    def __init__(self, name, port, filepath, additional_args=None):
         super(SocketThread, self).__init__()
+        if additional_args is None:
+            additional_args = []
         self.log = Logger.get_logger(self.__class__.__name__)
         self.setName(name)
         self.name = name


### PR DESCRIPTION
## Description
Run event server in tray with `--headless` flag so it won't show login UI when server is not available or credentials get invalid.