### PR TITLE
Do not use ftrack user in webpublisher

### DIFF
--- a/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
+++ b/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
@@ -16,7 +16,7 @@ import os
 import ftrack_api
 import pyblish.api
 import ayon_api
-from openpype.settings import get_project_settings
+
 from openpype.pipeline import KnownPublishError
 
 

--- a/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
+++ b/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
@@ -53,11 +53,6 @@ class CollectWebpublisherCredentials(pyblish.api.ContextPlugin):
         username = self._get_ftrack_username(user_email)
         os.environ["FTRACK_API_USER"] = username
 
-        burnin_name = username
-        if '@' in burnin_name:
-            burnin_name = burnin_name[:burnin_name.index('@')]
-        context.data["user"] = burnin_name
-
     def _get_ftrack_username(self, user_email):
         """Queries Ftrack api for user with 'user_email'.
 


### PR DESCRIPTION
## Description
User should not be filled with ftrack username during webpublisher. Webpublisher should fill the user based on AYON username instead.