### PR TITLE
Event handlers work only on AYON projects

### DIFF
--- a/client/ayon_ftrack/event_handlers_to_convert/action_prepare_project.py
+++ b/client/ayon_ftrack/event_handlers_to_convert/action_prepare_project.py
@@ -26,7 +26,7 @@ class PrepareProjectLocal(LocalAction):
 
     # Key to store info about trigerring create folder structure
     create_project_structure_key = "create_folder_structure"
-    create_project_structure_identifier = "create.project.structure"
+    create_project_structure_identifier = "ayon.create.project.structure"
     item_splitter = {"type": "label", "value": "---"}
     _keys_order = (
         "fps",

--- a/client/ayon_ftrack/event_handlers_user/action_batch_task_creation.py
+++ b/client/ayon_ftrack/event_handlers_user/action_batch_task_creation.py
@@ -15,7 +15,7 @@ class BatchTasksAction(LocalAction):
      '''
     label = "Batch Task Create"
     variant = None
-    identifier = "batch-tasks"
+    identifier = "ayon.batch-tasks"
     description = None
     icon = get_ftrack_icon_url("BatchTasks.svg")
 

--- a/client/ayon_ftrack/event_handlers_user/action_clean_hierarchical_attributes.py
+++ b/client/ayon_ftrack/event_handlers_user/action_clean_hierarchical_attributes.py
@@ -9,7 +9,7 @@ from ayon_ftrack.lib import get_ftrack_icon_url
 
 
 class CleanHierarchicalAttrsAction(LocalAction):
-    identifier = "clean.hierarchical.attr"
+    identifier = "ayon.clean.hierarchical.attr"
     label = "AYON Admin"
     variant = "- Clean hierarchical custom attributes"
     description = "Unset empty hierarchical attribute values."

--- a/client/ayon_ftrack/event_handlers_user/action_client_review_sort.py
+++ b/client/ayon_ftrack/event_handlers_user/action_client_review_sort.py
@@ -43,7 +43,7 @@ task_name_sort_kwargs = {task_name_kwarg_key: task_name_sorter}
 
 
 class ClientReviewSort(LocalAction):
-    identifier = "client.review.sort"
+    identifier = "ayon.client.review.sort"
     label = "Sort Review"
     icon = get_ftrack_icon_url("SortReview.svg")
 

--- a/client/ayon_ftrack/event_handlers_user/action_component_open.py
+++ b/client/ayon_ftrack/event_handlers_user/action_component_open.py
@@ -8,7 +8,7 @@ from openpype.lib import run_detached_process
 
 
 class ComponentOpen(LocalAction):
-    identifier = "component.open"
+    identifier = "ayon.component.open"
     label = "Open File"
     icon = get_ftrack_icon_url("ComponentOpen.svg")
 

--- a/client/ayon_ftrack/event_handlers_user/action_create_cust_attrs.py
+++ b/client/ayon_ftrack/event_handlers_user/action_create_cust_attrs.py
@@ -136,7 +136,7 @@ class CustAttrException(Exception):
 
 
 class CustomAttributes(LocalAction):
-    identifier = "create.update.attributes"
+    identifier = "ayon.create.update.attributes"
     label = "AYON Admin"
     variant = "- Create/Update Custom Attributes"
     description = "Creates required custom attributes in ftrack"

--- a/client/ayon_ftrack/event_handlers_user/action_create_folders.py
+++ b/client/ayon_ftrack/event_handlers_user/action_create_folders.py
@@ -8,7 +8,7 @@ from ayon_ftrack.lib import get_ftrack_icon_url
 
 
 class CreateFolders(LocalAction):
-    identifier = "create.folders"
+    identifier = "ayon.create.folders"
     label = "Create Folders"
     icon = get_ftrack_icon_url("CreateFolders.svg")
 

--- a/client/ayon_ftrack/event_handlers_user/action_create_project_structure.py
+++ b/client/ayon_ftrack/event_handlers_user/action_create_project_structure.py
@@ -51,7 +51,7 @@ class CreateProjectFolders(LocalAction):
     type exist in Ftrack.
     """
 
-    identifier = "create.project.structure"
+    identifier = "ayon.create.project.structure"
     label = "Create Project Structure"
     description = "Creates folder structure"
     role_list = ["Pypeclub", "Administrator", "Project Manager"]

--- a/client/ayon_ftrack/event_handlers_user/action_job_killer.py
+++ b/client/ayon_ftrack/event_handlers_user/action_job_killer.py
@@ -6,7 +6,7 @@ from ayon_ftrack.lib import get_ftrack_icon_url
 class JobKiller(LocalAction):
     """Kill jobs that are marked as running."""
 
-    identifier = "job.killer"
+    identifier = "ayon.job.killer"
     label = "AYON Admin"
     variant = "- Job Killer"
     description = "Killing selected running jobs"

--- a/client/ayon_ftrack/event_handlers_user/action_multiple_notes.py
+++ b/client/ayon_ftrack/event_handlers_user/action_multiple_notes.py
@@ -3,7 +3,7 @@ from ayon_ftrack.lib import get_ftrack_icon_url
 
 
 class MultipleNotes(LocalAction):
-    identifier = "multiple.notes"
+    identifier = "ayon.multiple.notes"
     label = "Multiple Notes"
     description = "Add same note to multiple entities"
     icon = get_ftrack_icon_url("MultipleNotes.svg")

--- a/client/ayon_ftrack/event_handlers_user/action_thumbnail_to_childern.py
+++ b/client/ayon_ftrack/event_handlers_user/action_thumbnail_to_childern.py
@@ -4,7 +4,7 @@ from ayon_ftrack.lib import get_ftrack_icon_url
 
 
 class ThumbToChildren(LocalAction):
-    identifier = "thumb.to.children"
+    identifier = "ayon.thumb.to.children"
     label = "Thumbnail"
     variant = " to Children"
     icon = get_ftrack_icon_url("Thumbnail.svg")

--- a/client/ayon_ftrack/event_handlers_user/action_thumbnail_to_parent.py
+++ b/client/ayon_ftrack/event_handlers_user/action_thumbnail_to_parent.py
@@ -4,7 +4,7 @@ from ayon_ftrack.lib import get_ftrack_icon_url
 
 
 class ThumbToParent(LocalAction):
-    identifier = "thumb.to.parent"
+    identifier = "ayon.thumb.to.parent"
     label = "Thumbnail"
     variant = " to Parent"
     icon = get_ftrack_icon_url("Thumbnail.svg")

--- a/client/ayon_ftrack/event_handlers_user/action_where_run_ask.py
+++ b/client/ayon_ftrack/event_handlers_user/action_where_run_ask.py
@@ -8,8 +8,8 @@ from ayon_ftrack.common import get_host_ip, LocalAction
 class ActionWhereIRun(LocalAction):
     """Show where same user has running AYON instances."""
 
-    identifier = "ask.where.i.run"
-    show_identifier = "show.where.i.run"
+    identifier = "ayon.ask.where.i.run"
+    show_identifier = "ayon.show.where.i.run"
     label = "AYON Admin"
     variant = "- Where I run"
     description = "Show PC info where user have running AYON"

--- a/services/processor/processor/default_handlers/action_clone_review_session.py
+++ b/services/processor/processor/default_handlers/action_clone_review_session.py
@@ -52,7 +52,7 @@ class CloneReviewSession(ServerAction):
      '''
     label = "Clone Review Session"
     variant = None
-    identifier = "clone-review-session"
+    identifier = "ayon.clone-review-session"
     description = None
     settings_key = "clone_review_session"
 

--- a/services/processor/processor/default_handlers/action_clone_review_session.py
+++ b/services/processor/processor/default_handlers/action_clone_review_session.py
@@ -50,7 +50,7 @@ class CloneReviewSession(ServerAction):
     `identifier` a unique identifier for your action.
     `description` a verbose descriptive text for you action
      '''
-    label = "Clone Review Session"
+    label = "Clone Review Session (AYON)"
     variant = None
     identifier = "ayon.clone-review-session"
     description = None

--- a/services/processor/processor/default_handlers/action_multiple_notes.py
+++ b/services/processor/processor/default_handlers/action_multiple_notes.py
@@ -9,7 +9,7 @@ class MultipleNotesServer(ServerAction):
     """
 
     identifier = "ayon.multiple.notes.server"
-    label = "Multiple Notes (Server)"
+    label = "Multiple Notes (Server - AYON)"
     description = "Add same note to multiple Asset Versions"
 
     _none_category = "__NONE__"

--- a/services/processor/processor/default_handlers/action_multiple_notes.py
+++ b/services/processor/processor/default_handlers/action_multiple_notes.py
@@ -8,7 +8,7 @@ class MultipleNotesServer(ServerAction):
     who triggered the action. It is possible to define note category of note.
     """
 
-    identifier = "multiple.notes.server"
+    identifier = "ayon.multiple.notes.server"
     label = "Multiple Notes (Server)"
     description = "Add same note to multiple Asset Versions"
 

--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -28,7 +28,7 @@ class PrepareProjectServer(ServerAction):
     description = "Set basic attributes on the project"
     icon = get_service_ftrack_icon_url("AYONAdmin.svg")
 
-    role_list = ["Pypeclub", "Administrator", "Project Manager"]
+    role_list = ["Administrator", "Project Manager"]
 
     settings_key = "prepare_project"
 

--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -22,7 +22,7 @@ class PrepareProjectServer(ServerAction):
     """Prepare project attributes in Anatomy."""
 
     default_preset_name = "__default__"
-    identifier = "prepare.project.server"
+    identifier = "ayon.prepare.project.server"
     label = "AYON Admin"
     variant = "- Prepare Project for AYON"
     description = "Set basic attributes on the project"

--- a/services/processor/processor/default_handlers/action_private_project_detection.py
+++ b/services/processor/processor/default_handlers/action_private_project_detection.py
@@ -5,7 +5,7 @@ class PrivateProjectDetectionAction(ServerAction):
     """Action helps to identify if does not have access to project."""
 
     identifier = "ayon.server.missing.perm.private.project"
-    label = "Missing permissions"
+    label = "Missing permissions (AYON)"
     description = (
         "Main ftrack event server does not have access to this project."
     )

--- a/services/processor/processor/default_handlers/action_private_project_detection.py
+++ b/services/processor/processor/default_handlers/action_private_project_detection.py
@@ -4,7 +4,7 @@ from ftrack_common.event_handlers import ServerAction
 class PrivateProjectDetectionAction(ServerAction):
     """Action helps to identify if does not have access to project."""
 
-    identifier = "server.missing.perm.private.project"
+    identifier = "ayon.server.missing.perm.private.project"
     label = "Missing permissions"
     description = (
         "Main ftrack event server does not have access to this project."

--- a/services/processor/processor/default_handlers/action_push_frame_values_to_task.py
+++ b/services/processor/processor/default_handlers/action_push_frame_values_to_task.py
@@ -43,7 +43,7 @@ class PushHierValuesToNonHier(ServerAction):
             - custom attribute for `Task`: frameStart: 1001
     """
 
-    identifier = "admin.push_hier_values_to_non_hier"
+    identifier = "ayon.admin.push_hier_values_to_non_hier"
     label = "AYON Admin"
     variant = "- Push Hierarchical values To Non-Hierarchical"
     icon = get_service_ftrack_icon_url("AYONAdmin.svg")

--- a/services/processor/processor/default_handlers/action_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/action_sync_from_ftrack.py
@@ -17,7 +17,7 @@ class SyncFromFtrackAction(ServerAction):
     description = "Synchronize project hierarchy based on ftrack"
     icon = get_service_ftrack_icon_url("AYONAdmin.svg")
 
-    role_list = ["Pypeclub", "Administrator", "Project Manager"]
+    role_list = ["Administrator", "Project Manager"]
 
     settings_key = "sync_from_ftrack"
 

--- a/services/processor/processor/default_handlers/action_tranfer_hierarchical_values.py
+++ b/services/processor/processor/default_handlers/action_tranfer_hierarchical_values.py
@@ -20,7 +20,7 @@ class TransferHierarchicalValues(ServerAction):
     - in, float -> string
     """
 
-    identifier = "transfer.hierarchical.values"
+    identifier = "ayon.transfer.hierarchical.values"
     label = "AYON Admin"
     variant = "- Transfer values between 2 custom attributes"
     description = (

--- a/services/processor/processor/default_handlers/event_first_version_status.py
+++ b/services/processor/processor/default_handlers/event_first_version_status.py
@@ -1,3 +1,7 @@
+import collections
+
+import ayon_api
+
 from ftrack_common import BaseEventHandler
 
 
@@ -73,8 +77,21 @@ class FirstVersionStatus(BaseEventHandler):
         if not self.task_status_map:
             return
 
-        entities_info = self.filter_event_ents(event)
-        if not entities_info:
+        filtered_entities_info = self.filter_entities_info(event)
+        if not filtered_entities_info:
+            return
+
+        for project_id, entities_info in filtered_entities_info.items():
+            self.process_by_project(session, event, project_id, entities_info)
+
+    def process_by_project(self, session, event, project_id, entities_info):
+        project_name = self.get_project_name_from_event(
+            session, event, project_id
+        )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug(
+                f"Project '{project_name}' not found in AYON. Skipping"
+            )
             return
 
         entity_ids = []
@@ -155,17 +172,17 @@ class FirstVersionStatus(BaseEventHandler):
                 )
 
     def filter_event_ents(self, event):
-        filtered_ents = []
-        for entity in event["data"].get("entities", []):
+        filtered_entities_info = collections.defaultdict(list)
+        for entity_info in event["data"].get("entities", []):
             # Care only about add actions
-            if entity.get("action") != "add":
+            if entity_info.get("action") != "add":
                 continue
 
             # Filter AssetVersions
-            if entity["entityType"] != "assetversion":
+            if entity_info["entityType"] != "assetversion":
                 continue
 
-            entity_changes = entity.get("changes") or {}
+            entity_changes = entity_info.get("changes") or {}
 
             # Check if version of Asset Version is `1`
             version_num = entity_changes.get("version", {}).get("new")
@@ -177,9 +194,18 @@ class FirstVersionStatus(BaseEventHandler):
             if not task_id:
                 continue
 
-            filtered_ents.append(entity)
+            project_id = None
+            for parent_item in reversed(entity_info["parents"]):
+                if parent_item["entityType"] == "show":
+                    project_id = parent_item["entityId"]
+                    break
 
-        return filtered_ents
+            if project_id is None:
+                continue
+
+            filtered_entities_info[project_id].append(entity_info)
+
+        return filtered_entities_info
 
 
 def register(session):

--- a/services/processor/processor/default_handlers/event_first_version_status.py
+++ b/services/processor/processor/default_handlers/event_first_version_status.py
@@ -171,7 +171,7 @@ class FirstVersionStatus(BaseEventHandler):
                     exc_info=True
                 )
 
-    def filter_event_ents(self, event):
+    def filter_entities_info(self, event):
         filtered_entities_info = collections.defaultdict(list)
         for entity_info in event["data"].get("entities", []):
             # Care only about add actions

--- a/services/processor/processor/default_handlers/event_next_task_update.py
+++ b/services/processor/processor/default_handlers/event_next_task_update.py
@@ -1,5 +1,6 @@
 import collections
 
+import ayon_api
 from ftrack_common import BaseEventHandler
 
 
@@ -100,6 +101,12 @@ class NextTaskUpdate(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug(
+                f"Project '{project_name}' not found in AYON. Skipping"
+            )
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/services/processor/processor/default_handlers/event_push_frame_values_to_task.py
+++ b/services/processor/processor/default_handlers/event_push_frame_values_to_task.py
@@ -2,6 +2,7 @@ import collections
 import copy
 from typing import Any
 
+import ayon_api
 import ftrack_api
 
 from ftrack_common import (
@@ -140,6 +141,12 @@ class PushHierValuesToNonHierEvent(BaseEventHandler):
         project_name: str = self.get_project_name_from_event(
             session, event, project_id
         )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug(
+                f"Project '{project_name}' not found in AYON. Skipping"
+            )
+            return set(), set()
+
         # Load settings
         project_settings: dict[str, Any] = (
             self.get_project_settings_from_event(event, project_name)

--- a/services/processor/processor/default_handlers/event_task_to_parent_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_parent_status.py
@@ -1,5 +1,7 @@
 import collections
 
+import ayon_api
+
 from ftrack_common import BaseEventHandler
 
 
@@ -61,6 +63,10 @@ class TaskStatusToParent(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug("Project not found in AYON. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/services/processor/processor/default_handlers/event_task_to_version_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_version_status.py
@@ -1,5 +1,7 @@
 import collections
 
+import ayon_api
+
 from ftrack_common import BaseEventHandler
 
 
@@ -103,6 +105,10 @@ class TaskToVersionStatus(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug("Project not found in AYON. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/services/processor/processor/default_handlers/event_thumbnail_updates.py
+++ b/services/processor/processor/default_handlers/event_thumbnail_updates.py
@@ -1,5 +1,7 @@
 import collections
 
+import ayon_api
+
 from ftrack_common import BaseEventHandler
 
 
@@ -23,6 +25,10 @@ class ThumbnailEvents(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug("Project not found in AYON. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/services/processor/processor/default_handlers/event_version_to_task_statuses.py
+++ b/services/processor/processor/default_handlers/event_version_to_task_statuses.py
@@ -1,3 +1,5 @@
+import ayon_api
+
 from ftrack_common import BaseEventHandler
 
 
@@ -50,6 +52,10 @@ class VersionToTaskStatus(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if ayon_api.get_project(project_name) is None:
+            self.log.debug("Project not found in AYON. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/services/processor/processor/handlers_to_convert/action_create_review_session.py
+++ b/services/processor/processor/handlers_to_convert/action_create_review_session.py
@@ -35,7 +35,7 @@ class CreateDailyReviewSessionServerAction(ServerAction):
     icon = get_service_ftrack_icon_url("AYONAdmin.svg")
     #: Action description.
     description = "Manually create daily review session"
-    role_list = {"Pypeclub", "Administrator", "Project Manager"}
+    role_list = {"Administrator", "Project Manager"}
 
     settings_key = "create_daily_review_session"
     default_template = "{yy}{mm}{dd}"


### PR DESCRIPTION
## Description
Ftrack event handlers are ignoring events from projects that are not available in AYON. Also action topics are not clashing with openpype actions. Some of the actions have AYON label in them so they can be recognized when used with OpenPype.