### PR TITLE
Ftrack: update asset names for multiple reviewable items

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -356,7 +356,8 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
             # add extended name if any
             if (
-                not self.keep_first_product_name_for_review
+                multiple_reviewable
+                and not self.keep_first_product_name_for_review
                 and extended_asset_name
             ):
                 other_item["asset_data"]["name"] = extended_asset_name


### PR DESCRIPTION
## Changelog Description
Multiple reviewable assetVersion components with better grouping to asset version name.

## Additional info
- Add a condition to also check if multiple_reviewable is True before updating the asset name.

## Testing notes:
1. very difficult to test but basically you need multiple reviewable representations marked as `ftrackreview`.

Source [PR](https://github.com/ynput/OpenPype/pull/6077)