### PR TITLE
Delete action is service action

### DIFF
--- a/server/settings/desktopapp_handlers.py
+++ b/server/settings/desktopapp_handlers.py
@@ -86,10 +86,6 @@ class FtrackDesktopAppHandlers(BaseSettingsModel):
         title="Clean hierarchical custom attributes",
         default_factory=SimpleAction
     )
-    delete_ayon_entities: SimpleAction = Field(
-        title="Delete Asset/Subsets",
-        default_factory=SimpleAction,
-    )
     delete_old_versions: SimpleAction = Field(
         title="Delete old versions",
         default_factory=SimpleAction,

--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -6,14 +6,12 @@ from ayon_server.settings import BaseSettingsModel, ensure_unique_names
 from .common import DictWithStrList, ROLES_TITLE
 
 
-class PrepareProjectAction(BaseSettingsModel):
+class SimpleAction(BaseSettingsModel):
     enabled: bool = True
-    role_list: list[str] = Field(default_factory=list, title=ROLES_TITLE)
-
-
-class SyncFromFtrackAction(BaseSettingsModel):
-    enabled: bool = True
-    role_list: list[str] = Field(default_factory=list, title=ROLES_TITLE)
+    role_list: list[str] = Field(
+        title=ROLES_TITLE,
+        default_factory=list,
+    )
 
 
 class SyncHierarchicalAttributes(BaseSettingsModel):
@@ -178,13 +176,13 @@ class CreateDailyReviewSession(BaseSettingsModel):
 class FtrackServiceHandlers(BaseSettingsModel):
     """Settings for event handlers running in ftrack service."""
 
-    prepare_project: PrepareProjectAction = Field(
+    prepare_project: SimpleAction = Field(
         title="Prepare Project",
-        default_factory=PrepareProjectAction,
+        default_factory=SimpleAction,
     )
-    sync_from_ftrack: SyncFromFtrackAction = Field(
+    sync_from_ftrack: SimpleAction = Field(
         title="Sync to AYON",
-        default_factory=SyncFromFtrackAction,
+        default_factory=SimpleAction,
     )
     sync_hier_entity_attributes: SyncHierarchicalAttributes = Field(
         title="Sync Hierarchical and Entity Attributes",
@@ -193,6 +191,10 @@ class FtrackServiceHandlers(BaseSettingsModel):
     clone_review_session: CloneReviewAction = Field(
         title="Clone Review Session",
         default_factory=CloneReviewAction,
+    )
+    delete_ayon_entities: SimpleAction = Field(
+        title="Delete Folders/Products",
+        default_factory=SimpleAction,
     )
     thumbnail_updates: ThumbnailHierarchyUpdates = Field(
         title="Update Hierarchy thumbnails",

--- a/services/processor/processor/default_handlers/action_delete_entities.py
+++ b/services/processor/processor/default_handlers/action_delete_entities.py
@@ -9,8 +9,11 @@ from ayon_api import (
     send_batch_operations,
 )
 
-from ayon_ftrack.common import create_chunks, LocalAction
-from ayon_ftrack.lib import get_ftrack_icon_url
+from ftrack_common import (
+    create_chunks,
+    ServerAction,
+    get_service_ftrack_icon_url,
+)
 
 
 class AyonData:
@@ -47,13 +50,13 @@ class AyonData:
         self.folder_ids_to_delete = folder_ids_to_delete
 
 
-class DeleteEntitiesAction(LocalAction):
+class DeleteEntitiesAction(ServerAction):
     identifier = "delete.ayon.entities"
     label = "Delete Folders/Products"
     description = (
         "Remove entities from AYON and from ftrack with all children"
     )
-    icon = get_ftrack_icon_url("DeleteAsset.svg")
+    icon = get_service_ftrack_icon_url("DeleteAsset.svg")
 
     settings_key = "delete_ayon_entities"
 


### PR DESCRIPTION
## Description
Moved Delete Folders/Products to service event handlers so user don't have to have runnin ayon launcher to run it.

With that were also moved settings,


### Additional information
I could not find a reason why the action should be local and not service. Could anyone think of a reason?