### PR TITLE
Disable ftrack per project

### DIFF
--- a/client/ayon_ftrack/common/__init__.py
+++ b/client/ayon_ftrack/common/__init__.py
@@ -26,6 +26,7 @@ __all__ = (
 
     "InvalidFpsValue",
 
+    "is_ftrack_enabled_in_settings",
     "join_filter_values",
     "create_chunks",
     "convert_to_fps",
@@ -78,6 +79,7 @@ from .exceptions import (
 )
 
 from .lib import (
+    is_ftrack_enabled_in_settings,
     join_filter_values,
     create_chunks,
     convert_to_fps,

--- a/client/ayon_ftrack/common/event_handlers/ftrack_action_handler.py
+++ b/client/ayon_ftrack/common/event_handlers/ftrack_action_handler.py
@@ -467,7 +467,9 @@ class BaseAction(BaseHandler):
             event["data"]["user_roles"] = user_roles
         return user_roles
 
-    def get_project_name_from_event(self, session, event, entities):
+    def get_project_name_from_event_with_entities(
+        self, session, event, entities
+    ):
         """Load or query and fill project entity from/to event data.
 
         Project data are stored by ftrack id because in most cases it is
@@ -491,7 +493,7 @@ class BaseAction(BaseHandler):
         return project_name
 
     def get_ftrack_settings(self, session, event, entities):
-        project_name = self.get_project_name_from_event(
+        project_name = self.get_project_name_from_event_with_entities(
             session, event, entities
         )
         project_settings = self.get_project_settings_from_event(

--- a/client/ayon_ftrack/common/event_handlers/ftrack_event_handler.py
+++ b/client/ayon_ftrack/common/event_handlers/ftrack_event_handler.py
@@ -13,45 +13,6 @@ class BaseEventHandler(BaseHandler):
     subscription_topic = "ftrack.update"
     handler_type = "Event"
 
-    def get_project_name_from_event(self, session, event, project_id):
-        """Load or query and fill project entity from/to event data.
-
-        Project data are stored by ftrack id because in most cases it is
-        easier to access project id than project name.
-
-        Args:
-            session (ftrack_api.Session): Current session.
-            event (ftrack_api.Event): Processed event by session.
-            project_id (str): Ftrack project id.
-
-        Returns:
-            Union[str, None]: Project name based on entities or None if project
-                cannot be defined.
-        """
-
-        if not project_id:
-            raise ValueError(
-                "Entered `project_id` is not valid. {} ({})".format(
-                    str(project_id), str(type(project_id))
-                )
-            )
-        # Try to get project entity from event
-        project_data = event["data"].get("project_data")
-        if not project_data:
-            project_data = {}
-            event["data"]["project_data"] = project_data
-
-        project_name = project_data.get(project_id)
-        if not project_name:
-            # Get project entity from task and store to event
-            project_entity = session.query((
-                "select full_name from Project where id is \"{}\""
-            ).format(project_id)).first()
-            if project_entity:
-                project_name = project_entity["full_name"]
-            event["data"]["project_data"][project_id] = project_name
-        return project_name
-
     def _process(self, event):
         return self._launch(event)
 

--- a/client/ayon_ftrack/common/event_handlers/ftrack_event_handler.py
+++ b/client/ayon_ftrack/common/event_handlers/ftrack_event_handler.py
@@ -13,31 +13,6 @@ class BaseEventHandler(BaseHandler):
     subscription_topic = "ftrack.update"
     handler_type = "Event"
 
-    def _process(self, event):
-        return self._launch(event)
-
-    def _launch(self, event):
-        """Callback kept for backwards compatibility.
-
-        Will be removed when default
-        """
-
-        self.session.rollback()
-        self.session._local_cache.clear()
-
-        try:
-            self.process(event)
-
-        except Exception as exc:
-            self.session.rollback()
-            self.session._configure_locations()
-            self.log.error(
-                "Event \"{}\" Failed: {}".format(
-                    self.__class__.__name__, str(exc)
-                ),
-                exc_info=True
-            )
-
     def register(self):
         """Register to subscription topic."""
 
@@ -45,23 +20,6 @@ class BaseEventHandler(BaseHandler):
             "topic={}".format(self.subscription_topic),
             self._process,
             priority=self.priority
-        )
-
-    def _translate_event(self, event, session=None):
-        """Receive entity objects based on event.
-
-        Args:
-            event (ftrack_api.Event): Event to process.
-            session (ftrack_api.Session): Connected ftrack session.
-
-        Returns:
-            List[ftrack_api.Entity]: Queried entities based on event data.
-        """
-
-        return self._get_entities(
-            event,
-            session,
-            ignore=["socialfeed", "socialnotification", "team"]
         )
 
     def process(self, event):
@@ -90,3 +48,45 @@ class BaseEventHandler(BaseHandler):
         """
 
         raise NotImplementedError()
+
+    def _process(self, event):
+        return self._launch(event)
+
+    def _launch(self, event):
+        """Callback kept for backwards compatibility.
+
+        Will be removed when default
+        """
+
+        self.session.rollback()
+        self.session._local_cache.clear()
+
+        try:
+            self.process(event)
+
+        except Exception as exc:
+            self.session.rollback()
+            self.session._configure_locations()
+            self.log.error(
+                "Event \"{}\" Failed: {}".format(
+                    self.__class__.__name__, str(exc)
+                ),
+                exc_info=True
+            )
+
+    def _translate_event(self, event, session=None):
+        """Receive entity objects based on event.
+
+        Args:
+            event (ftrack_api.Event): Event to process.
+            session (ftrack_api.Session): Connected ftrack session.
+
+        Returns:
+            List[ftrack_api.Entity]: Queried entities based on event data.
+        """
+
+        return self._get_entities(
+            event,
+            session,
+            ignore=["socialfeed", "socialnotification", "team"]
+        )

--- a/client/ayon_ftrack/common/lib.py
+++ b/client/ayon_ftrack/common/lib.py
@@ -12,6 +12,27 @@ from ayon_api import (
 from .exceptions import InvalidFpsValue
 
 
+def is_ftrack_enabled_in_settings(project_settings):
+    """Check if ftrack is enabled in ftrack project settings.
+
+    Project settings gives option to disable ftrack integration per project.
+    That should disable most of ftrack integration functionality, especially
+    pipeline integration > publish plugins, and some automations like event
+    server handlers.
+
+    Args:
+        project_settings (dict[str, Any]): Ftrack project settings.
+
+    Returns:
+        bool: True if ftrack is enabled in project settings.
+    """
+
+    ftrack_enabled = project_settings.get("ftrack_enabled")
+    if ftrack_enabled is None:
+        return True
+    return ftrack_enabled
+
+
 def join_filter_values(values):
     """Prepare values to be used for filtering in ftrack query.
 

--- a/client/ayon_ftrack/pipeline/__init__.py
+++ b/client/ayon_ftrack/pipeline/__init__.py
@@ -1,8 +1,0 @@
-from .plugin import (
-    apply_ftrack_settings,
-)
-
-
-__all__ = (
-    "apply_ftrack_settings",
-)

--- a/client/ayon_ftrack/pipeline/__init__.py
+++ b/client/ayon_ftrack/pipeline/__init__.py
@@ -1,0 +1,8 @@
+from .plugin import (
+    apply_ftrack_settings,
+)
+
+
+__all__ = (
+    "apply_ftrack_settings",
+)

--- a/client/ayon_ftrack/pipeline/plugin.py
+++ b/client/ayon_ftrack/pipeline/plugin.py
@@ -1,0 +1,48 @@
+import pyblish.api
+from openpype.pipeline.publish import (
+    get_plugin_settings,
+    apply_plugin_settings_automatically,
+)
+from ayon_ftrack.common import is_ftrack_enabled_in_settings
+
+
+class FtrackPublishContextPlugin(pyblish.api.ContextPlugin):
+    settings_category = "ftrack"
+
+    @classmethod
+    def is_ftrack_enabled(cls, project_settings):
+        return is_ftrack_enabled_in_settings(
+            project_settings.get("ftrack") or {}
+        )
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        if not cls.is_ftrack_enabled(project_settings):
+            cls.enabled = False
+            return
+
+        plugin_settins = get_plugin_settings(
+            cls, project_settings, cls.log, None
+        )
+        apply_plugin_settings_automatically(cls, plugin_settins, cls.log)
+
+
+class FtrackPublishInstancePlugin(pyblish.api.InstancePlugin):
+    settings_category = "ftrack"
+
+    @classmethod
+    def is_ftrack_enabled(cls, project_settings):
+        return is_ftrack_enabled_in_settings(
+            project_settings.get("ftrack") or {}
+        )
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        if not cls.is_ftrack_enabled(project_settings):
+            cls.enabled = False
+            return
+
+        plugin_settins = get_plugin_settings(
+            cls, project_settings, cls.log, None
+        )
+        apply_plugin_settings_automatically(cls, plugin_settins, cls.log)

--- a/client/ayon_ftrack/pipeline/plugin.py
+++ b/client/ayon_ftrack/pipeline/plugin.py
@@ -5,14 +5,16 @@ from openpype.pipeline.publish import (
 )
 from ayon_ftrack.common import is_ftrack_enabled_in_settings
 
+SETTINGS_CATEGORY = "ftrack"
+
 
 class FtrackPublishContextPlugin(pyblish.api.ContextPlugin):
-    settings_category = "ftrack"
+    settings_category = SETTINGS_CATEGORY
 
     @classmethod
     def is_ftrack_enabled(cls, project_settings):
         return is_ftrack_enabled_in_settings(
-            project_settings.get("ftrack") or {}
+            project_settings.get(SETTINGS_CATEGORY) or {}
         )
 
     @classmethod
@@ -28,12 +30,12 @@ class FtrackPublishContextPlugin(pyblish.api.ContextPlugin):
 
 
 class FtrackPublishInstancePlugin(pyblish.api.InstancePlugin):
-    settings_category = "ftrack"
+    settings_category = SETTINGS_CATEGORY
 
     @classmethod
     def is_ftrack_enabled(cls, project_settings):
         return is_ftrack_enabled_in_settings(
-            project_settings.get("ftrack") or {}
+            project_settings.get(SETTINGS_CATEGORY) or {}
         )
 
     @classmethod

--- a/client/ayon_ftrack/plugins/publish/collect_custom_attributes_data.py
+++ b/client/ayon_ftrack/plugins/publish/collect_custom_attributes_data.py
@@ -10,9 +10,10 @@ Provides:
 import copy
 
 import pyblish.api
+from ayon_ftrack.pipeline import plugin
 
 
-class CollectFtrackCustomAttributeData(pyblish.api.ContextPlugin):
+class CollectFtrackCustomAttributeData(plugin.FtrackContextPlugin):
     """Collect custom attribute values and store them to customData.
 
     Data are stored into each instance in context under
@@ -21,8 +22,6 @@ class CollectFtrackCustomAttributeData(pyblish.api.ContextPlugin):
     Hierarchical attributes are not looked up properly for that functionality
     custom attribute values lookup must be extended.
     """
-
-    settings_category = "ftrack"
 
     order = pyblish.api.CollectorOrder + 0.4992
     label = "Collect Ftrack Custom Attribute Data"

--- a/client/ayon_ftrack/plugins/publish/collect_custom_attributes_data.py
+++ b/client/ayon_ftrack/plugins/publish/collect_custom_attributes_data.py
@@ -13,7 +13,7 @@ import pyblish.api
 from ayon_ftrack.pipeline import plugin
 
 
-class CollectFtrackCustomAttributeData(plugin.FtrackContextPlugin):
+class CollectFtrackCustomAttributeData(plugin.FtrackPublishContextPlugin):
     """Collect custom attribute values and store them to customData.
 
     Data are stored into each instance in context under

--- a/client/ayon_ftrack/plugins/publish/collect_ftrack_api.py
+++ b/client/ayon_ftrack/plugins/publish/collect_ftrack_api.py
@@ -5,24 +5,23 @@ import pyblish.api
 import ayon_api
 
 from ayon_ftrack.common import FTRACK_ID_ATTRIB
+from ayon_ftrack.pipeline import plugin
 try:
     from openpype.client import get_asset_name_identifier
 except ImportError:
     get_asset_name_identifier = None
 
 
-class CollectFtrackApi(pyblish.api.ContextPlugin):
+class CollectFtrackApi(plugin.FtrackPublishContextPlugin):
     """ Collects an ftrack session and the current task id. """
 
     order = pyblish.api.CollectorOrder + 0.4991
     label = "Collect Ftrack Api"
 
-    settings_category = "ftrack"
-
     def process(self, context):
-        ftrack_log = logging.getLogger('ftrack_api')
+        ftrack_log = logging.getLogger("ftrack_api")
         ftrack_log.setLevel(logging.WARNING)
-        ftrack_log = logging.getLogger('ftrack_api_old')
+        ftrack_log = logging.getLogger("ftrack_api_old")
         ftrack_log.setLevel(logging.WARNING)
 
         # Collect session

--- a/client/ayon_ftrack/plugins/publish/collect_ftrack_family.py
+++ b/client/ayon_ftrack/plugins/publish/collect_ftrack_family.py
@@ -9,8 +9,10 @@ import pyblish.api
 
 from openpype.lib import filter_profiles
 
+from ayon_ftrack.pipeline import plugin
 
-class CollectFtrackFamily(pyblish.api.InstancePlugin):
+
+class CollectFtrackFamily(plugin.FtrackPublishInstancePlugin):
     """Adds explicitly 'ftrack' to families to upload instance to FTrack.
 
     Uses selection by combination of hosts/families/tasks names via
@@ -25,8 +27,6 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
 
     label = "Collect Ftrack Family"
     order = pyblish.api.CollectorOrder + 0.4990
-
-    settings_category = "ftrack"
 
     profiles = None
 

--- a/client/ayon_ftrack/plugins/publish/collect_local_ftrack_creds.py
+++ b/client/ayon_ftrack/plugins/publish/collect_local_ftrack_creds.py
@@ -3,15 +3,15 @@
 import os
 import pyblish.api
 
+from ayon_ftrack.pipeline import plugin
 
-class CollectLocalFtrackCreds(pyblish.api.ContextPlugin):
+
+class CollectLocalFtrackCreds(plugin.FtrackPublishContextPlugin):
     """Collect default Royal Render path."""
 
     order = pyblish.api.CollectorOrder + 0.01
     label = "Collect local ftrack credentials"
     targets = ["rr_control"]
-
-    settings_category = "ftrack"
 
     def process(self, context):
         if (

--- a/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
+++ b/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
@@ -19,8 +19,10 @@ import ayon_api
 
 from openpype.pipeline import KnownPublishError
 
+from ayon_ftrack.pipeline import plugin
 
-class CollectWebpublisherCredentials(pyblish.api.ContextPlugin):
+
+class CollectWebpublisherCredentials(plugin.FtrackPublishContextPlugin):
     """
         Translates uploader's user email to Ftrack username.
 
@@ -31,8 +33,6 @@ class CollectWebpublisherCredentials(pyblish.api.ContextPlugin):
     `representation.context.username`
 
     """
-
-    settings_category = "ftrack"
 
     order = pyblish.api.CollectorOrder + 0.0015
     label = "Collect webpublisher credentials"

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_api.py
@@ -20,7 +20,7 @@ from ayon_ftrack.common.constants import FTRACK_ID_ATTRIB
 from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackApi(plugin.FtrackInstancePlugin):
+class IntegrateFtrackApi(plugin.FtrackPublishInstancePlugin):
     """ Commit components to server. """
 
     order = pyblish.api.IntegratorOrder + 0.499

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_api.py
@@ -17,16 +17,15 @@ import pyblish.api
 import clique
 
 from ayon_ftrack.common.constants import FTRACK_ID_ATTRIB
+from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackApi(pyblish.api.InstancePlugin):
+class IntegrateFtrackApi(plugin.FtrackInstancePlugin):
     """ Commit components to server. """
 
     order = pyblish.api.IntegratorOrder + 0.499
     label = "Integrate Ftrack Api"
     families = ["ftrack"]
-
-    settings_category = "ftrack"
 
     def process(self, instance):
         component_list = instance.data.get("ftrackComponentsList")

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_component_overwrite.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_component_overwrite.py
@@ -1,25 +1,25 @@
 import pyblish.api
+from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackComponentOverwrite(pyblish.api.InstancePlugin):
+class IntegrateFtrackComponentOverwrite(plugin.FtrackPublishInstancePlugin):
     """
     Set `component_overwrite` to True on all instances `ftrackComponentsList`
     """
 
     order = pyblish.api.IntegratorOrder + 0.49
-    label = 'Overwrite ftrack created versions'
+    label = "Overwrite ftrack created versions"
     families = ["clip"]
-    settings_category = "ftrack"
     optional = True
     active = False
 
     def process(self, instance):
-        component_list = instance.data.get('ftrackComponentsList')
+        component_list = instance.data.get("ftrackComponentsList")
         if not component_list:
             self.log.info("No component to overwrite...")
             return
 
         for cl in component_list:
-            cl['component_overwrite'] = True
-            self.log.debug('Component {} overwriting'.format(
-                cl['component_data']['name']))
+            cl["component_overwrite"] = True
+            name = cl["component_data"]["name"]
+            self.log.debug("Component {} overwriting".format(name))

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
@@ -15,7 +15,7 @@ from openpype.lib import StringTemplate
 from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackDescription(plugin.FtrackInstancePlugin):
+class IntegrateFtrackDescription(plugin.FtrackPublishInstancePlugin):
     """Add description to AssetVersions in Ftrack."""
 
     # Must be after integrate asset new

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
@@ -12,8 +12,10 @@ import six
 import pyblish.api
 from openpype.lib import StringTemplate
 
+from ayon_ftrack.pipeline import plugin
 
-class IntegrateFtrackDescription(pyblish.api.InstancePlugin):
+
+class IntegrateFtrackDescription(plugin.FtrackInstancePlugin):
     """Add description to AssetVersions in Ftrack."""
 
     # Must be after integrate asset new
@@ -21,7 +23,6 @@ class IntegrateFtrackDescription(pyblish.api.InstancePlugin):
     label = "Integrate Ftrack description"
     families = ["ftrack"]
     optional = True
-    settings_category = "ftrack"
 
     # Can be set in settings:
     # - Allows `intent` and `comment` keys

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_farm_status.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_farm_status.py
@@ -1,8 +1,10 @@
 import pyblish.api
 from openpype.lib import filter_profiles
 
+from ayon_ftrack.pipeline import plugin
 
-class IntegrateFtrackFarmStatus(pyblish.api.ContextPlugin):
+
+class IntegrateFtrackFarmStatus(plugin.FtrackContextPlugin):
     """Change task status when should be published on farm.
 
     Instance which has set "farm" key in data to 'True' is considered as will
@@ -11,7 +13,6 @@ class IntegrateFtrackFarmStatus(pyblish.api.ContextPlugin):
 
     order = pyblish.api.IntegratorOrder + 0.48
     label = "Integrate Ftrack Farm Status"
-    settings_category = "ftrack"
     farm_status_profiles = []
 
     def process(self, context):

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_farm_status.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_farm_status.py
@@ -4,7 +4,7 @@ from openpype.lib import filter_profiles
 from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackFarmStatus(plugin.FtrackContextPlugin):
+class IntegrateFtrackFarmStatus(plugin.FtrackPublishContextPlugin):
     """Change task status when should be published on farm.
 
     Instance which has set "farm" key in data to 'True' is considered as will

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -12,8 +12,10 @@ from openpype.lib.transcoding import (
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.lib.transcoding import VIDEO_EXTENSIONS
 
+from ayon_ftrack.pipeline import plugin
 
-class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
+
+class IntegrateFtrackInstance(plugin.FtrackInstancePlugin):
     """Collect ftrack component data (not integrate yet).
 
     Add ftrack component list to instance.
@@ -22,7 +24,6 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
     order = pyblish.api.IntegratorOrder + 0.48
     label = "Integrate Ftrack Component"
     families = ["ftrack"]
-    settings_category = "ftrack"
 
     metadata_keys_to_label = {
         "openpype_version": "OpenPype version",

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -15,7 +15,7 @@ from openpype.lib.transcoding import VIDEO_EXTENSIONS
 from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackInstance(plugin.FtrackInstancePlugin):
+class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
     """Collect ftrack component data (not integrate yet).
 
     Add ftrack component list to instance.

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_note.py
@@ -15,8 +15,10 @@ import six
 import pyblish.api
 from openpype.lib import StringTemplate
 
+from ayon_ftrack.pipeline import plugin
 
-class IntegrateFtrackNote(pyblish.api.InstancePlugin):
+
+class IntegrateFtrackNote(plugin.FtrackInstancePlugin):
     """Create comments in Ftrack."""
 
     # Must be after integrate asset new
@@ -24,7 +26,6 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
     label = "Integrate Ftrack note"
     families = ["ftrack"]
     optional = True
-    settings_category = "ftrack"
 
     # Can be set in presets:
     # - Allows only `intent` and `comment` keys

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_note.py
@@ -18,7 +18,7 @@ from openpype.lib import StringTemplate
 from ayon_ftrack.pipeline import plugin
 
 
-class IntegrateFtrackNote(plugin.FtrackInstancePlugin):
+class IntegrateFtrackNote(plugin.FtrackPublishInstancePlugin):
     """Create comments in Ftrack."""
 
     # Must be after integrate asset new

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
@@ -7,7 +7,7 @@ from ayon_ftrack.common import create_chunks
 from ayon_ftrack.pipeline import plugin
 
 
-class CollectFtrackTaskStatuses(plugin.FtrackContextPlugin):
+class CollectFtrackTaskStatuses(plugin.FtrackPublishContextPlugin):
     """Collect available task statuses on the project.
 
     This is preparation for integration of task statuses.
@@ -53,7 +53,7 @@ class CollectFtrackTaskStatuses(plugin.FtrackContextPlugin):
         self.log.debug("Collected ftrack task statuses.")
 
 
-class IntegrateFtrackStatusBase(plugin.FtrackInstancePlugin):
+class IntegrateFtrackStatusBase(plugin.FtrackPublishInstancePlugin):
     """Base plugin for status collection.
 
     Requirements:
@@ -317,7 +317,7 @@ class IntegrateFtrackOnFarmStatus(IntegrateFtrackStatusBase):
     settings_key = "ftrack_task_status_on_farm_publish"
 
 
-class IntegrateFtrackTaskStatus(plugin.FtrackContextPlugin):
+class IntegrateFtrackTaskStatus(plugin.FtrackPublishContextPlugin):
     # Use order of Integrate Ftrack Api plugin and offset it before or after
     base_order = pyblish.api.IntegratorOrder + 0.499
     # By default is after Integrate Ftrack Api

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
@@ -4,9 +4,10 @@ import pyblish.api
 from openpype.lib import filter_profiles
 
 from ayon_ftrack.common import create_chunks
+from ayon_ftrack.pipeline import plugin
 
 
-class CollectFtrackTaskStatuses(pyblish.api.ContextPlugin):
+class CollectFtrackTaskStatuses(plugin.FtrackContextPlugin):
     """Collect available task statuses on the project.
 
     This is preparation for integration of task statuses.
@@ -25,7 +26,6 @@ class CollectFtrackTaskStatuses(pyblish.api.ContextPlugin):
     # After 'CollectFtrackApi'
     order = pyblish.api.CollectorOrder + 0.4992
     label = "Collect Ftrack Task Statuses"
-    settings_category = "ftrack"
 
     def process(self, context):
         ftrack_session = context.data("ftrackSession")
@@ -53,7 +53,7 @@ class CollectFtrackTaskStatuses(pyblish.api.ContextPlugin):
         self.log.debug("Collected ftrack task statuses.")
 
 
-class IntegrateFtrackStatusBase(pyblish.api.InstancePlugin):
+class IntegrateFtrackStatusBase(plugin.FtrackInstancePlugin):
     """Base plugin for status collection.
 
     Requirements:
@@ -73,6 +73,10 @@ class IntegrateFtrackStatusBase(pyblish.api.InstancePlugin):
 
     @classmethod
     def apply_settings(cls, project_settings):
+        if not cls.is_ftrack_enabled(project_settings):
+            cls.enabled = False
+            return
+
         settings_key = cls.settings_key
         if settings_key is None:
             settings_key = cls.__name__
@@ -313,7 +317,7 @@ class IntegrateFtrackOnFarmStatus(IntegrateFtrackStatusBase):
     settings_key = "ftrack_task_status_on_farm_publish"
 
 
-class IntegrateFtrackTaskStatus(pyblish.api.ContextPlugin):
+class IntegrateFtrackTaskStatus(plugin.FtrackContextPlugin):
     # Use order of Integrate Ftrack Api plugin and offset it before or after
     base_order = pyblish.api.IntegratorOrder + 0.499
     # By default is after Integrate Ftrack Api
@@ -327,6 +331,10 @@ class IntegrateFtrackTaskStatus(pyblish.api.ContextPlugin):
         Args:
             project_settings (dict[str, Any]): Project settings.
         """
+
+        if not cls.is_ftrack_enabled(project_settings):
+            cls.enabled = False
+            return
 
         settings = (
             project_settings["ftrack"]["publish"]["IntegrateFtrackTaskStatus"]

--- a/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -17,7 +17,7 @@ except ImportError:
     get_asset_name_identifier = None
 
 
-class IntegrateHierarchyToFtrack(plugin.FtrackContextPlugin):
+class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
     """
     Create entities in ftrack based on collected data from premiere
     Example of entry data:

--- a/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -9,6 +9,7 @@ from openpype.client import get_asset_by_id
 from openpype.lib import filter_profiles
 from openpype.pipeline import KnownPublishError
 from ayon_ftrack.common import get_ayon_attr_configs
+from ayon_ftrack.pipeline import plugin
 
 try:
     from openpype.client import get_asset_name_identifier
@@ -16,7 +17,7 @@ except ImportError:
     get_asset_name_identifier = None
 
 
-class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
+class IntegrateHierarchyToFtrack(plugin.FtrackContextPlugin):
     """
     Create entities in ftrack based on collected data from premiere
     Example of entry data:
@@ -51,7 +52,6 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
         "traypublisher"
     ]
     optional = False
-    settings_category = "ftrack"
     create_task_status_profiles = []
 
     def process(self, context):

--- a/client/ayon_ftrack/plugins/publish/validate_custom_ftrack_attributes.py
+++ b/client/ayon_ftrack/plugins/publish/validate_custom_ftrack_attributes.py
@@ -1,8 +1,10 @@
 import pyblish.api
 from openpype.pipeline.publish import ValidateContentsOrder
 
+from ayon_ftrack.pipeline import plugin
 
-class ValidateFtrackAttributes(pyblish.api.InstancePlugin):
+
+class ValidateFtrackAttributes(plugin.FtrackInstancePlugin):
     """
     This will validate attributes in ftrack against data in scene.
 
@@ -37,7 +39,7 @@ class ValidateFtrackAttributes(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     families = ["ftrack"]
     optional = True
-    settings_category = "ftrack"
+
     # Ignore standalone host, because it does not have an Ftrack entity
     # associated.
     hosts = [

--- a/client/ayon_ftrack/plugins/publish/validate_custom_ftrack_attributes.py
+++ b/client/ayon_ftrack/plugins/publish/validate_custom_ftrack_attributes.py
@@ -4,7 +4,7 @@ from openpype.pipeline.publish import ValidateContentsOrder
 from ayon_ftrack.pipeline import plugin
 
 
-class ValidateFtrackAttributes(plugin.FtrackInstancePlugin):
+class ValidateFtrackAttributes(plugin.FtrackPublishInstancePlugin):
     """
     This will validate attributes in ftrack against data in scene.
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -68,6 +68,11 @@ class PostLaunchHookSettings(BaseSettingsModel):
 class FtrackSettings(BaseSettingsModel):
     """Ftrack addon settings."""
 
+    ftrack_enabled: bool = Field(
+        True,
+        # TODO think about the label - it is not clear what it does
+        title="Enable ftrack addon"
+    )
     ftrack_server: str = Field(
         "",
         title="Ftrack server url",
@@ -102,6 +107,7 @@ class FtrackSettings(BaseSettingsModel):
 
 
 DEFAULT_VALUES = {
+    "ftrack_enabled": True,
     "ftrack_server": "",
     "service_event_handlers": DEFAULT_SERVICE_HANDLERS_SETTINGS,
     "service_settings": {

--- a/services/processor/processor/default_handlers/action_delete_entities.py
+++ b/services/processor/processor/default_handlers/action_delete_entities.py
@@ -3,7 +3,6 @@ import copy
 import collections
 
 from ayon_api import (
-    get_project,
     get_folders,
     get_products,
     send_batch_operations,

--- a/services/processor/processor/default_handlers/action_delete_entities.py
+++ b/services/processor/processor/default_handlers/action_delete_entities.py
@@ -542,7 +542,8 @@ class DeleteEntitiesAction(ServerAction):
         # Check if project exists in AYON
         project = self.get_project_from_entity(entities[0], session)
         project_name = project["full_name"]
-        if not get_project(project_name):
+        ayon_project = self.get_ayon_project_from_event(event, project_name)
+        if not ayon_project:
             return {
                 "success": False,
                 "message": f"Project '{project_name}' not found in AYON."

--- a/services/processor/processor/default_handlers/event_first_version_status.py
+++ b/services/processor/processor/default_handlers/event_first_version_status.py
@@ -88,7 +88,8 @@ class FirstVersionStatus(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+
+        if not self.get_ayon_project_from_event(event, project_name):
             self.log.debug(
                 f"Project '{project_name}' not found in AYON. Skipping"
             )

--- a/services/processor/processor/default_handlers/event_next_task_update.py
+++ b/services/processor/processor/default_handlers/event_next_task_update.py
@@ -1,6 +1,6 @@
 import collections
 
-from ftrack_common import BaseEventHandler
+from ftrack_common import BaseEventHandler, is_ftrack_enabled_in_settings
 
 
 class NextTaskUpdate(BaseEventHandler):
@@ -110,11 +110,16 @@ class NextTaskUpdate(BaseEventHandler):
         project_settings = self.get_project_settings_from_event(
             event, project_name
         )
+        ftrack_settings = project_settings["ftrack"]
+        if not is_ftrack_enabled_in_settings(ftrack_settings):
+            self.log.debug("ftrack is disabled for project \"{}\"".format(
+                project_name
+            ))
+            return
 
         # Load status mapping from presets
         event_settings = (
-            project_settings
-            ["ftrack"]
+            ftrack_settings
             ["service_event_handlers"]
             [self.settings_key]
         )

--- a/services/processor/processor/default_handlers/event_next_task_update.py
+++ b/services/processor/processor/default_handlers/event_next_task_update.py
@@ -1,6 +1,5 @@
 import collections
 
-import ayon_api
 from ftrack_common import BaseEventHandler
 
 

--- a/services/processor/processor/default_handlers/event_next_task_update.py
+++ b/services/processor/processor/default_handlers/event_next_task_update.py
@@ -101,7 +101,7 @@ class NextTaskUpdate(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+        if not self.get_ayon_project_from_event(event, project_name):
             self.log.debug(
                 f"Project '{project_name}' not found in AYON. Skipping"
             )

--- a/services/processor/processor/default_handlers/event_push_frame_values_to_task.py
+++ b/services/processor/processor/default_handlers/event_push_frame_values_to_task.py
@@ -141,7 +141,7 @@ class PushHierValuesToNonHierEvent(BaseEventHandler):
         project_name: str = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+        if not self.get_ayon_project_from_event(event, project_name):
             self.log.debug(
                 f"Project '{project_name}' not found in AYON. Skipping"
             )

--- a/services/processor/processor/default_handlers/event_push_frame_values_to_task.py
+++ b/services/processor/processor/default_handlers/event_push_frame_values_to_task.py
@@ -2,7 +2,6 @@ import collections
 import copy
 from typing import Any
 
-import ayon_api
 import ftrack_api
 
 from ftrack_common import (

--- a/services/processor/processor/default_handlers/event_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_sync_from_ftrack.py
@@ -8,7 +8,6 @@ import arrow
 import ftrack_api
 
 from ayon_api import (
-    get_project,
     get_folders,
     get_tasks,
     slugify_string,

--- a/services/processor/processor/default_handlers/event_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_sync_from_ftrack.py
@@ -1599,8 +1599,9 @@ class AutoSyncFromFtrack(BaseEventHandler):
             )
             return
 
-        project = get_project(sync_process.project_name)
-        if project is None:
+        if not self.get_ayon_project_from_event(
+            event, sync_process.project_name
+        ):
             self.log.debug(
                 f"Project '{sync_process.project_name}' was not"
                 " found in AYON. Skipping."

--- a/services/processor/processor/default_handlers/event_task_to_parent_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_parent_status.py
@@ -63,7 +63,8 @@ class TaskStatusToParent(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+
+        if not self.get_ayon_project_from_event(event, project_name):
             self.log.debug("Project not found in AYON. Skipping")
             return
 

--- a/services/processor/processor/default_handlers/event_task_to_parent_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_parent_status.py
@@ -1,6 +1,6 @@
 import collections
 
-from ftrack_common import BaseEventHandler
+from ftrack_common import BaseEventHandler, is_ftrack_enabled_in_settings
 
 
 class TaskStatusToParent(BaseEventHandler):
@@ -70,6 +70,12 @@ class TaskStatusToParent(BaseEventHandler):
         project_settings = self.get_project_settings_from_event(
             event, project_name
         )
+        ftrack_settings = project_settings["ftrack"]
+        if not is_ftrack_enabled_in_settings(ftrack_settings):
+            self.log.debug("ftrack is disabled for project \"{}\"".format(
+                project_name
+            ))
+            return
 
         # Prepare loaded settings and check if can be processed
         result = self.prepare_settings(project_settings, project_name)

--- a/services/processor/processor/default_handlers/event_task_to_parent_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_parent_status.py
@@ -1,7 +1,5 @@
 import collections
 
-import ayon_api
-
 from ftrack_common import BaseEventHandler
 
 

--- a/services/processor/processor/default_handlers/event_task_to_version_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_version_status.py
@@ -105,7 +105,7 @@ class TaskToVersionStatus(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+        if not self.get_ayon_project_from_event(event, project_name):
             self.log.debug("Project not found in AYON. Skipping")
             return
 

--- a/services/processor/processor/default_handlers/event_task_to_version_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_version_status.py
@@ -1,6 +1,6 @@
 import collections
 
-from ftrack_common import BaseEventHandler
+from ftrack_common import BaseEventHandler, is_ftrack_enabled_in_settings
 
 
 class TaskToVersionStatus(BaseEventHandler):
@@ -111,10 +111,15 @@ class TaskToVersionStatus(BaseEventHandler):
         project_settings = self.get_project_settings_from_event(
             event, project_name
         )
+        ftrack_settings = project_settings["ftrack"]
+        if not is_ftrack_enabled_in_settings(ftrack_settings):
+            self.log.debug("ftrack is disabled for project \"{}\"".format(
+                project_name
+            ))
+            return
 
         event_settings = (
-            project_settings
-            ["ftrack"]
+            ftrack_settings
             ["service_event_handlers"]
             [self.settings_key]
         )

--- a/services/processor/processor/default_handlers/event_task_to_version_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_version_status.py
@@ -1,7 +1,5 @@
 import collections
 
-import ayon_api
-
 from ftrack_common import BaseEventHandler
 
 

--- a/services/processor/processor/default_handlers/event_thumbnail_updates.py
+++ b/services/processor/processor/default_handlers/event_thumbnail_updates.py
@@ -1,6 +1,6 @@
 import collections
 
-from ftrack_common import BaseEventHandler
+from ftrack_common import BaseEventHandler, is_ftrack_enabled_in_settings
 
 
 class ThumbnailEvents(BaseEventHandler):
@@ -32,10 +32,15 @@ class ThumbnailEvents(BaseEventHandler):
         project_settings = self.get_project_settings_from_event(
             event, project_name
         )
+        ftrack_settings = project_settings["ftrack"]
+        if not is_ftrack_enabled_in_settings(ftrack_settings):
+            self.log.debug("ftrack is disabled for project \"{}\"".format(
+                project_name
+            ))
+            return
 
         event_settings = (
-            project_settings
-            ["ftrack"]
+            ftrack_settings
             ["service_event_handlers"]
             [self.settings_key]
         )

--- a/services/processor/processor/default_handlers/event_thumbnail_updates.py
+++ b/services/processor/processor/default_handlers/event_thumbnail_updates.py
@@ -1,7 +1,5 @@
 import collections
 
-import ayon_api
-
 from ftrack_common import BaseEventHandler
 
 

--- a/services/processor/processor/default_handlers/event_thumbnail_updates.py
+++ b/services/processor/processor/default_handlers/event_thumbnail_updates.py
@@ -25,7 +25,8 @@ class ThumbnailEvents(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+        project = self.get_ayon_project_from_event(event, project_name)
+        if project is None:
             self.log.debug("Project not found in AYON. Skipping")
             return
 

--- a/services/processor/processor/default_handlers/event_version_to_task_statuses.py
+++ b/services/processor/processor/default_handlers/event_version_to_task_statuses.py
@@ -1,4 +1,4 @@
-from ftrack_common import BaseEventHandler
+from ftrack_common import BaseEventHandler, is_ftrack_enabled_in_settings
 
 
 class VersionToTaskStatus(BaseEventHandler):
@@ -58,11 +58,16 @@ class VersionToTaskStatus(BaseEventHandler):
         project_settings = self.get_project_settings_from_event(
             event, project_name
         )
+        ftrack_settings = project_settings["ftrack"]
+        if not is_ftrack_enabled_in_settings(ftrack_settings):
+            self.log.debug("ftrack is disabled for project \"{}\"".format(
+                project_name
+            ))
+            return
 
         # Load status mapping from presets
         event_settings = (
-            project_settings
-            ["ftrack"]
+            ftrack_settings
             ["service_event_handlers"]
             ["status_version_to_task"]
         )

--- a/services/processor/processor/default_handlers/event_version_to_task_statuses.py
+++ b/services/processor/processor/default_handlers/event_version_to_task_statuses.py
@@ -1,5 +1,3 @@
-import ayon_api
-
 from ftrack_common import BaseEventHandler
 
 

--- a/services/processor/processor/default_handlers/event_version_to_task_statuses.py
+++ b/services/processor/processor/default_handlers/event_version_to_task_statuses.py
@@ -52,7 +52,7 @@ class VersionToTaskStatus(BaseEventHandler):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
-        if ayon_api.get_project(project_name) is None:
+        if not self.get_ayon_project_from_event(event, project_name):
             self.log.debug("Project not found in AYON. Skipping")
             return
 


### PR DESCRIPTION
## Description
Added option to disable ftrack addon on project level. Publish plugins are disabled and event handlers will skip their processing.

### Additional information
That doesn't meant the addon is not available on the project. All logic pieces that are per project logic must validate from settings if are enabled or not.

### Settings screenshot
![image](https://github.com/ynput/ayon-ftrack/assets/43494761/3de4fd75-dc01-47c1-a522-baaac2296ce5)
