### PR TITLE
Prelaunch hook: Find ftrack entity

### DIFF
--- a/client/ayon_ftrack/common/__init__.py
+++ b/client/ayon_ftrack/common/__init__.py
@@ -26,6 +26,9 @@ __all__ = (
 
     "InvalidFpsValue",
 
+    "import_filepath",
+    "modules_from_path",
+
     "is_ftrack_enabled_in_settings",
     "join_filter_values",
     "create_chunks",
@@ -47,9 +50,6 @@ __all__ = (
     "BaseAction",
     "LocalAction",
     "ServerAction",
-
-    "import_filepath",
-    "modules_from_path",
 
     "FtrackServer",
 )
@@ -78,6 +78,11 @@ from .exceptions import (
     InvalidFpsValue,
 )
 
+from .python_module_tools import (
+    import_filepath,
+    modules_from_path,
+)
+
 from .lib import (
     is_ftrack_enabled_in_settings,
     join_filter_values,
@@ -104,11 +109,6 @@ from .event_handlers import (
     BaseAction,
     LocalAction,
     ServerAction,
-)
-
-from .python_module_tools import (
-    import_filepath,
-    modules_from_path,
 )
 
 from .ftrack_server import FtrackServer

--- a/client/ayon_ftrack/common/__init__.py
+++ b/client/ayon_ftrack/common/__init__.py
@@ -45,6 +45,8 @@ __all__ = (
     "app_definitions_from_app_manager",
     "tool_definitions_from_app_manager",
 
+    "get_folder_path_for_entities",
+
     "BaseHandler",
     "BaseEventHandler",
     "BaseAction",
@@ -101,6 +103,9 @@ from .custom_attributes import (
     default_custom_attributes_definition,
     app_definitions_from_app_manager,
     tool_definitions_from_app_manager,
+)
+from .utils import (
+    get_folder_path_for_entities,
 )
 
 from .event_handlers import (

--- a/client/ayon_ftrack/common/lib.py
+++ b/client/ayon_ftrack/common/lib.py
@@ -15,6 +15,9 @@ from .exceptions import InvalidFpsValue
 def is_ftrack_enabled_in_settings(project_settings):
     """Check if ftrack is enabled in ftrack project settings.
 
+    This function expect settings for a specific project. It is not checking
+    if ftrack is enabled in general.
+
     Project settings gives option to disable ftrack integration per project.
     That should disable most of ftrack integration functionality, especially
     pipeline integration > publish plugins, and some automations like event
@@ -28,6 +31,8 @@ def is_ftrack_enabled_in_settings(project_settings):
     """
 
     ftrack_enabled = project_settings.get("ftrack_enabled")
+    # If 'ftrack_enabled' is not set, we assume it is enabled.
+    # - this is for backwards compatibility - remove in future
     if ftrack_enabled is None:
         return True
     return ftrack_enabled

--- a/client/ayon_ftrack/common/utils.py
+++ b/client/ayon_ftrack/common/utils.py
@@ -1,0 +1,78 @@
+"""Utils for ftrack.
+
+Whereas lib.py contains utils for general use, this module contains utils
+    for certain situations, or functions that would cause circular import
+    when implemented in lib.py.
+
+It is possible that some functions will be moved from lib.py to this module
+    to keep consistency.
+"""
+
+from .constants import CUST_ATTR_KEY_SERVER_PATH
+from .custom_attributes import query_custom_attribute_values
+
+
+def get_folder_path_for_entities(
+    session, entities, path_cust_attr_id=None, allow_use_link=True
+):
+    """Get folder path for ftrack entities.
+
+    Folder path is received from custom attribute, or from entity link
+        which contains name of parent entities.
+
+    Args:
+        session (ftrack_api.Session): Connected ftrack session.
+        entities (List[dict]): List of ftrack entities.
+        path_cust_attr_id (Union[str, None]): Custom attribute
+            configuration id which stores entity path.
+        allow_use_link (bool): Use 'link' value if path is not found in
+            custom attributes.
+
+    Returns:
+        dict[str, Union[str, None]]: Entity path by ftrack entity id.
+            Output will always contain all entity ids from input.
+    """
+
+    entities_by_id = {
+        entity["id"]: entity
+        for entity in entities
+    }
+    entity_ids = set(entities_by_id.keys())
+    folder_paths_by_id = {
+        entity_id: None
+        for entity_id in entity_ids
+    }
+    if not folder_paths_by_id:
+        return folder_paths_by_id
+
+    if path_cust_attr_id is None:
+        cust_attr_conf = session.query(
+            "select id, key from CustomAttributeConfiguration"
+            f" where key is '{CUST_ATTR_KEY_SERVER_PATH}'"
+        ).first()
+        if cust_attr_conf:
+            path_cust_attr_id = cust_attr_conf["id"]
+
+    value_items = []
+    if path_cust_attr_id is not None:
+        value_items = query_custom_attribute_values(
+            session, {path_cust_attr_id}, entity_ids
+        )
+
+    for value_item in value_items:
+        path = value_item["value"]
+        entity_id = value_item["entity_id"]
+        if path:
+            entity_ids.discard(entity_id)
+            folder_paths_by_id[entity_id] = path
+
+    if allow_use_link:
+        for missing_id in entity_ids:
+            entity = entities_by_id[missing_id]
+            # Use stupidly simple solution
+            link_names = [item["name"] for item in entity["link"]]
+            # Change project name to empty string
+            link_names[0] = ""
+            folder_paths_by_id[missing_id] = "/".join(link_names)
+
+    return folder_paths_by_id

--- a/client/ayon_ftrack/launch_hooks/post_ftrack_changes.py
+++ b/client/ayon_ftrack/launch_hooks/post_ftrack_changes.py
@@ -1,8 +1,10 @@
 import os
 
+import ayon_api
 import ftrack_api
 
 from ayon_ftrack.common import (
+    FTRACK_ID_ATTRIB,
     is_ftrack_enabled_in_settings,
 )
 
@@ -27,23 +29,24 @@ class PostFtrackHook(PostLaunchHook):
         folder_path = self.data.get("asset_name")
         task_name = self.data.get("task_name")
 
-        missing_context_keys = []
-        if not project_name:
-            missing_context_keys.append("project_name")
-        if not project_settings:
-            missing_context_keys.append("project_settings")
-        if not folder_path:
-            missing_context_keys.append("asset_name")
-        if not task_name:
-            missing_context_keys.append("task_name")
-
+        missing_context_keys = [
+            key
+            for value, key in (
+                (project_name, "project_name"),
+                (project_settings, "project_settings"),
+                (folder_path, "asset_name"),
+                (task_name, "task_name"),
+            )
+            if not value
+        ]
         if missing_context_keys:
             missing_keys_str = ", ".join([
-                "\"{}\"".format(key) for key in missing_context_keys
+                f"'{key}'" for key in missing_context_keys
             ])
-            self.log.debug("Hook {} skipped. Missing data keys: {}".format(
-                self.__class__.__name__, missing_keys_str
-            ))
+            self.log.debug(
+                f"Hook {self.__class__.__name__} skipped."
+                f" Missing required data: {missing_keys_str}"
+            )
             return
 
         if "ftrack" not in project_settings:
@@ -61,72 +64,35 @@ class PostFtrackHook(PostLaunchHook):
         required_keys = ("FTRACK_SERVER", "FTRACK_API_USER", "FTRACK_API_KEY")
         for key in required_keys:
             if not os.environ.get(key):
-                self.log.debug((
-                    "Missing required environment \"{}\""
-                    " for Ftrack after launch procedure."
-                ).format(key))
+                self.log.debug(
+                    f"Missing required environment '{key}'"
+                    " for ftrack post launch procedure."
+                )
                 return
 
         try:
-            session = ftrack_api.Session(auto_connect_event_hub=True)
-            self.log.debug("Ftrack session created")
+            session = ftrack_api.Session(auto_connect_event_hub=False)
+            self.log.debug("ftrack session created")
         except Exception:
-            self.log.warning("Couldn't create Ftrack session")
+            self.log.warning("Couldn't create ftrack session")
             return
 
         try:
-            entity = self.find_ftrack_task_entity(
-                session, project_name, asset_name, task_name
+            entity = self._find_ftrack_task_entity(
+                session, project_name, folder_path, task_name
             )
             if entity:
                 self.ftrack_status_change(session, entity, project_name)
 
         except Exception:
             self.log.warning(
-                "Couldn't finish Ftrack procedure.", exc_info=True
+                "Couldn't finish ftrack post launch logic.",
+                exc_info=True
             )
             return
 
         finally:
             session.close()
-
-    def find_ftrack_task_entity(
-        self, session, project_name, asset_name, task_name
-    ):
-        project_entity = session.query(
-            "Project where full_name is \"{}\"".format(project_name)
-        ).first()
-        if not project_entity:
-            self.log.warning(
-                "Couldn't find project \"{}\" in Ftrack.".format(project_name)
-            )
-            return
-
-        potential_task_entities = session.query((
-            "TypedContext where parent.name is \"{}\" and project_id is \"{}\""
-        ).format(asset_name, project_entity["id"])).all()
-        filtered_entities = []
-        for _entity in potential_task_entities:
-            if (
-                _entity.entity_type.lower() == "task"
-                and _entity["name"] == task_name
-            ):
-                filtered_entities.append(_entity)
-
-        if not filtered_entities:
-            self.log.warning((
-                "Couldn't find task \"{}\" under parent \"{}\" in Ftrack."
-            ).format(task_name, asset_name))
-            return
-
-        if len(filtered_entities) > 1:
-            self.log.warning((
-                "Found more than one task \"{}\""
-                " under parent \"{}\" in Ftrack."
-            ).format(task_name, asset_name))
-            return
-
-        return filtered_entities[0]
 
     def ftrack_status_change(self, session, entity, project_name):
         project_settings = get_project_settings(project_name)
@@ -137,18 +103,14 @@ class PostFtrackHook(PostLaunchHook):
         )
         if not status_update["enabled"]:
             self.log.debug(
-                "Status changes are disabled for project \"{}\"".format(
-                    project_name
-                )
+                f"Status changes are disabled for project '{project_name}'"
             )
             return
 
         status_mapping = status_update["mapping"]
         if not status_mapping:
             self.log.warning(
-                "Project \"{}\" does not have set status changes.".format(
-                    project_name
-                )
+                f"Project '{project_name}' does not have set status changes."
             )
             return
 
@@ -157,14 +119,19 @@ class PostFtrackHook(PostLaunchHook):
         ent_path = "/".join(
             [ent["name"] for ent in entity["link"]]
         )
+        # TODO refactor
         while True:
             next_status_name = None
             for item in status_mapping:
                 new_status = item["name"]
-                from_statuses = item["value"]
                 if new_status in already_tested:
                     continue
-                if actual_status in from_statuses or "__any__" in from_statuses:
+
+                from_statuses = item["value"]
+                if (
+                    actual_status in from_statuses
+                    or "__any__" in from_statuses
+                ):
                     if new_status != "__ignore__":
                         next_status_name = new_status
                         already_tested.add(new_status)
@@ -174,23 +141,95 @@ class PostFtrackHook(PostLaunchHook):
             if next_status_name is None:
                 break
 
-            try:
-                query = "Status where name is \"{}\"".format(
-                    next_status_name
+            status = session.query(
+                f"Status where name is \"{next_status_name}\""
+            ).first()
+            if status is None:
+                self.log.warning(
+                    f"Status '{next_status_name}' not found in ftrack."
                 )
-                status = session.query(query).one()
+                continue
 
-                entity["status"] = status
+            try:
+                entity["status_id"] = status["id"]
                 session.commit()
-                self.log.debug("Changing status to \"{}\" <{}>".format(
-                    next_status_name, ent_path
-                ))
+                self.log.debug(
+                    f"Status changed to \"{next_status_name}\" <{ent_path}>"
+                )
                 break
 
             except Exception:
                 session.rollback()
-                msg = (
-                    "Status \"{}\" in presets wasn't found"
-                    " on Ftrack entity type \"{}\""
-                ).format(next_status_name, entity.entity_type)
-                self.log.warning(msg)
+                self.log.warning(
+                    f"Status '{next_status_name}' is not available"
+                    f" for ftrack entity type '{entity.entity_type}'"
+                )
+
+    def _find_ftrack_folder_entity(self, session, folder):
+        """
+        Args:
+            session (ftrack_api.Session): Ftrack session.
+            folder (dict): AYON folder data.
+
+        Returns:
+            Union[ftrack_api.entity.base.Entity, None]: Ftrack folder entity.
+        """
+
+        # Find ftrack entity by id stored on folder
+        # - Maybe more options could be used? Find ftrack entity by folder
+        #   path in ftrack custom attributes.
+        if folder:
+            ftrack_id = folder["attrib"].get(FTRACK_ID_ATTRIB)
+            if ftrack_id:
+                entity = session.query(
+                    f"TypedContext where id is \"{ftrack_id}\""
+                ).first()
+                if entity:
+                    return entity
+        return None
+
+    def _find_ftrack_task_entity(
+        self, session, project_name, folder_path, task_name
+    ):
+        """
+
+        Args:
+            session (ftrack_api.Session): Ftrack session.
+            project_name (str): Project name.
+            folder_path (str): Folder path.
+            task_name (str): Task name.
+
+        Returns:
+            Union[ftrack_api.entity.base.Entity, None]: Ftrack task entity.
+        """
+
+        project_entity = session.query(
+            f"Project where full_name is \"{project_name}\""
+        ).first()
+        if not project_entity:
+            self.log.warning(
+                f"Couldn't find project '{project_name}' in ftrack."
+            )
+            return None
+
+        # TODO use 'folder' entity data from launch context when is available.
+        #   At this moment there is only "asset doc".
+        folder = ayon_api.get_folder_by_path(project_name, folder_path)
+        parent_entity = self._find_ftrack_folder_entity(session, folder)
+        if parent_entity is None:
+            self.log.warning(
+                f"Couldn't find folder '{folder_path}' in ftrack"
+                f" project '{project_name}'."
+            )
+            return None
+
+        parent_id = parent_entity["id"]
+        task_entity = session.query(
+            f"Task where parent_id is '{parent_id}' and name is '{task_name}'"
+        ).first()
+        if task_entity is None:
+            self.log.warning(
+                f"Couldn't find task '{folder_path}/{task_name}' in ftrack."
+            )
+
+        return task_entity


### PR DESCRIPTION
## Description
Enhanced ftrack prelaunch hook to change status on application launch. The most important change is how parent of ftrack task is found which fixes the hook core logic. Some refactors were made. We're checking if ftrack is enabled for a project before we do any logic.

EDITED:
It was discovered that ftrack application launch logic did not use folder path which caused a lot of troubles, like not changing the status. That was fixed in this PR too.

## Testing notes
1. Upload addon to AYON server OR point path in dev bundle to `client` directory
2. Start ayon launcher
3. Launch an application
4. That should trigger change of status (by default should change status to In Progress)