### PR TITLE
Change look of enabled checkbox in settings UI

### DIFF
--- a/client/ayon_ftrack/common/lib.py
+++ b/client/ayon_ftrack/common/lib.py
@@ -30,7 +30,7 @@ def is_ftrack_enabled_in_settings(project_settings):
         bool: True if ftrack is enabled in project settings.
     """
 
-    ftrack_enabled = project_settings.get("ftrack_enabled")
+    ftrack_enabled = project_settings.get("enabled")
     # If 'ftrack_enabled' is not set, we assume it is enabled.
     # - this is for backwards compatibility - remove in future
     if ftrack_enabled is None:

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -68,11 +68,7 @@ class PostLaunchHookSettings(BaseSettingsModel):
 class FtrackSettings(BaseSettingsModel):
     """Ftrack addon settings."""
 
-    ftrack_enabled: bool = Field(
-        True,
-        # TODO think about the label - it is not clear what it does
-        title="Enable ftrack addon"
-    )
+    enabled: bool = Field(True)
     ftrack_server: str = Field(
         "",
         title="Ftrack server url",
@@ -107,7 +103,7 @@ class FtrackSettings(BaseSettingsModel):
 
 
 DEFAULT_VALUES = {
-    "ftrack_enabled": True,
+    "enabled": True,
     "ftrack_server": "",
     "service_event_handlers": DEFAULT_SERVICE_HANDLERS_SETTINGS,
     "service_settings": {


### PR DESCRIPTION
## Description
Change name of `ftrack_enabled` to `enabled` to move the checkbox to header of ftrack settings.

![image](https://github.com/ynput/ayon-ftrack/assets/43494761/5e6c0567-d681-4625-a106-f3f1383188cb)
