### PR TITLE
Use correct key for new task types

### DIFF
--- a/services/processor/processor/default_handlers/event_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_sync_from_ftrack.py
@@ -1241,7 +1241,7 @@ class SyncProcess:
             else:
                 new_task_types.append({
                     "name": task_type_name,
-                    "short_name": re.sub(r"\W+", "", task_type_name.lower())
+                    "shortName": re.sub(r"\W+", "", task_type_name.lower())
                 })
 
         project_entity.task_types = new_task_types

--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -396,7 +396,7 @@ class SyncFromFtrack:
             else:
                 new_task_types.append({
                     "name": name,
-                    "short_name": re.sub(r"\W+", "", name.lower())
+                    "shortName": re.sub(r"\W+", "", name.lower())
                 })
 
         project_entity.folder_types = new_folder_types


### PR DESCRIPTION
## Description
Use `'shortName'` instead of `'short_name'` for new task types in project.