### PR TITLE
Tweak Settings docstring for PostLaunchHookSettings

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -47,10 +47,10 @@ class PostLaunchHookMapping(BaseSettingsModel):
 class PostLaunchHookSettings(BaseSettingsModel):
     """Change task status on application launch.
 
-    Changeo of status is based on mapping. Each item in mapping define new
-    status which is used based on current status/es. Special value for current
-    statuses is '__any__', in that case the new status is always used. And if
-    new status name is '__ignore__', the change of status is skipped if current
+    Change of status is based on mapping. Each item in mapping defines new
+    status which is used based on current status(es). Special value for current
+    statuses is `__any__`, in that case the new status is always used. And if
+    new status name is `__ignore__`, the change of status is skipped if current
     status is in current statuses list.
     """
 


### PR DESCRIPTION
Tweak grammar, plus replace ' -> ` to avoid markdown formatting to make bold words

Formatting didn't look so well up on the site:
![image](https://github.com/ynput/ayon-ftrack/assets/2439881/d0b1f162-b5d6-4c20-b67a-1cdf394ce1ef)

E.g. '__any__' should be `__any__`

**Note: Only thing that I feel is still lacking in the description is the order of strength, Is first match first served? (Which seems like it's not because default top entry starts with `__any__` so I guess it'd always be the case?)**

