### PR TITLE
Use new naming in settings

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
@@ -117,8 +117,8 @@ class IntegrateFtrackStatusBase(plugin.FtrackPublishInstancePlugin):
                 "host_names": ["nuke"],
                 "task_types": ["Compositing"],
                 "task_names": ["Comp"],
-                "families": ["render"],
-                "subset_names": ["renderComp"],
+                "product_types": ["render"],
+                "product_names": ["renderComp"],
                 "status_name": "Rendering",
             }
 
@@ -151,8 +151,8 @@ class IntegrateFtrackStatusBase(plugin.FtrackPublishInstancePlugin):
             "host_names": context.data["hostName"],
             "task_types": task_entity["type"]["name"],
             "task_names": task_entity["name"],
-            "families": instance.data["productType"],
-            "subset_names": instance.data["productName"],
+            "product_types": instance.data["productType"],
+            "product_names": instance.data["productName"],
         }
 
     def is_valid_instance(self, context, instance):
@@ -256,9 +256,6 @@ class IntegrateFtrackFarmStatus(IntegrateFtrackStatusBase):
     def get_status_profiles(self):
         if self.status_profiles is None:
             profiles = copy.deepcopy(self.farm_status_profiles)
-            for profile in profiles:
-                profile["host_names"] = profile.pop("hosts")
-                profile["subset_names"] = profile.pop("subsets")
             self.status_profiles = profiles
         return self.status_profiles
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -135,7 +135,8 @@ class FtrackAddon(BaseServerAddon):
         overrides: dict[str, Any],
     ) -> dict[str, Any]:
         self._convert_integrate_ftrack_status_settings(overrides)
-        return overrides
+        # Use super conversion
+        return await super().convert_settings_overrides(overrides)
 
     def _convert_integrate_ftrack_status_settings(self, overrides):
         """Convert settings of 'IntegrateFtrackFarmStatus' profiles.

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,5 +1,5 @@
 import semver
-from typing import Type
+from typing import Type, Any
 
 from ayon_server.addons import BaseServerAddon, AddonLibrary
 from ayon_server.lib.postgres import Postgres
@@ -129,3 +129,34 @@ class FtrackAddon(BaseServerAddon):
             )
         return True
 
+    async def convert_settings_overrides(
+        self,
+        source_version: str,
+        overrides: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._convert_integrate_ftrack_status_settings(overrides)
+        return overrides
+
+    def _convert_integrate_ftrack_status_settings(self, overrides):
+        value = overrides
+        for key in (
+            "publish",
+            "IntegrateFtrackFarmStatus",
+            "farm_status_profiles",
+        ):
+            if not isinstance(value, dict) or key not in value:
+                return
+
+            value = value[key]
+
+        if not isinstance(value, list):
+            return
+
+        for profile in value:
+            for src_key, dst_key in (
+                ("hosts", "host_names"),
+                ("families", "product_types"),
+                ("subset_names", "product_names"),
+            ):
+                if src_key in profile:
+                    profile[dst_key] = profile.pop(src_key)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -138,6 +138,14 @@ class FtrackAddon(BaseServerAddon):
         return overrides
 
     def _convert_integrate_ftrack_status_settings(self, overrides):
+        """Convert settings of 'IntegrateFtrackFarmStatus' profiles.
+
+        This change happened in 1.1.0 version of the addon, where the settings
+        were converted to use AYON naming convention over OpenPype convention.
+
+        Args:
+            overrides (dict[str, Any]): Settings overrides.
+        """
         value = overrides
         for key in (
             "publish",

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -136,7 +136,9 @@ class FtrackAddon(BaseServerAddon):
     ) -> dict[str, Any]:
         self._convert_integrate_ftrack_status_settings(overrides)
         # Use super conversion
-        return await super().convert_settings_overrides(overrides)
+        return await super().convert_settings_overrides(
+            source_version, overrides
+        )
 
     def _convert_integrate_ftrack_status_settings(self, overrides):
         """Convert settings of 'IntegrateFtrackFarmStatus' profiles.

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -258,13 +258,13 @@ class FtrackTaskStatusProfile(BaseSettingsModel):
         default_factory=list,
         title="Task names",
     )
-    families: list[str] = Field(
+    product_types: list[str] = Field(
         default_factory=list,
-        title="Families",
+        title="Product types",
     )
-    subset_names: list[str] = Field(
+    product_names: list[str] = Field(
         default_factory=list,
-        title="Subset names",
+        title="Product names",
     )
     status_name: str = Field(
         "",
@@ -708,15 +708,15 @@ DEFAULT_PUBLISH_SETTINGS = {
     "IntegrateFtrackFarmStatus": {
         "farm_status_profiles": [
             {
-                "hosts": [
+                "host_names": [
                     "celaction"
                 ],
                 "task_types": [],
                 "task_names": [],
-                "families": [
+                "product_types": [
                     "render"
                 ],
-                "subsets": [],
+                "product_names": [],
                 "status_name": "Render"
             }
         ]

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -185,7 +185,7 @@ def integrate_ftrack_metadata_enum():
 class IntegrateFtrackInstanceModel(BaseSettingsModel):
     _isGroup = True
     product_type_mapping: list[IntegrateFtrackFamilyMapping] = Field(
-        title="Family Mapping",
+        title="Product type Mapping",
         default_factory=list,
     )
     keep_first_product_name_for_review: bool = Field(
@@ -355,7 +355,7 @@ class FtrackPublishPlugins(BaseSettingsModel):
         title="Integrate Ftrack Farm Status",
         default_factory=IntegrateFtrackFarmStatusModel,
         description=(
-            "Change status of task when it's subset is submitted to farm"
+            "Change status of task when it's product is submitted to farm"
         ),
     )
     ftrack_task_status_local_publish: FtrackTaskStatusLocalModel = Field(


### PR DESCRIPTION
## Description
Use product name and type instead of subset and family in settings.

## Additional information
Added conversion of overrides because of possible issues with settings conversions from older versions.