### PR TITLE
Fix Integrate ftrack farm status settings

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_status.py
@@ -257,8 +257,17 @@ class IntegrateFtrackFarmStatus(IntegrateFtrackStatusBase):
         if self.status_profiles is None:
             profiles = copy.deepcopy(self.farm_status_profiles)
             for profile in profiles:
-                profile["host_names"] = profile.pop("hosts")
-                profile["subset_names"] = profile.pop("subsets")
+                if "hosts" in profile:
+                    profile["host_names"] = profile.pop("hosts")
+
+                if "product_types" in profile:
+                    profile["families"] = profile.pop("product_types")
+
+                if "subsets" in profile:
+                    profile["subset_names"] = profile.pop("subsets")
+                elif "product_names" in profile:
+                    profile["subset_names"] = profile.pop("product_names")
+
             self.status_profiles = profiles
         return self.status_profiles
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -708,15 +708,15 @@ DEFAULT_PUBLISH_SETTINGS = {
     "IntegrateFtrackFarmStatus": {
         "farm_status_profiles": [
             {
-                "hosts": [
+                "host_names": [
                     "celaction"
                 ],
                 "task_types": [],
                 "task_names": [],
-                "families": [
+                "product_types": [
                     "render"
                 ],
-                "subsets": [],
+                "product_names": [],
                 "status_name": "Render"
             }
         ]


### PR DESCRIPTION
## Description
Integrate ftrack farm status is using wrong settings keys for current implementation of the plugin. Added correct keys in default settings and added more conversions to handle all the cases.