### PR TITLE
Add AYON version id to integrated AssetVersion

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -15,6 +15,7 @@ from ayon_core.lib.transcoding import VIDEO_EXTENSIONS, IMAGE_EXTENSIONS
 
 from ayon_ftrack import __version__
 from ayon_ftrack.pipeline import plugin
+from ayon_ftrack.common.constants import CUST_ATTR_KEY_SERVER_ID
 
 
 class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
@@ -104,6 +105,13 @@ class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
 
         # Base of component item data
         # - create a copy of this object when want to use it
+        version_entity = instance.data.get("versionEntity")
+        av_custom_attributes = {}
+        if version_entity:
+            av_custom_attributes[CUST_ATTR_KEY_SERVER_ID] = (
+                version_entity["id"]
+            )
+
         base_component_item = {
             "assettype_data": {
                 "short": asset_type,
@@ -114,7 +122,8 @@ class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
             "assetversion_data": {
                 "version": version_number,
                 "comment": instance.context.data.get("comment") or "",
-                "status_name": status_name
+                "status_name": status_name,
+                "custom_attributes": av_custom_attributes
             },
             "component_overwrite": False,
             # This can be change optionally

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -15,7 +15,10 @@ from ayon_core.lib.transcoding import VIDEO_EXTENSIONS, IMAGE_EXTENSIONS
 
 from ayon_ftrack import __version__
 from ayon_ftrack.pipeline import plugin
-from ayon_ftrack.common.constants import CUST_ATTR_KEY_SERVER_ID
+from ayon_ftrack.common.constants import (
+    CUST_ATTR_KEY_SERVER_ID,
+    CUST_ATTR_KEY_SERVER_PATH,
+)
 
 
 class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
@@ -108,9 +111,15 @@ class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
         version_entity = instance.data.get("versionEntity")
         av_custom_attributes = {}
         if version_entity:
-            av_custom_attributes[CUST_ATTR_KEY_SERVER_ID] = (
-                version_entity["id"]
-            )
+            version_path = "/".join([
+                instance.data["folderPath"],
+                instance.data["productName"],
+                "v{:0>3}".format(version_entity["version"])
+            ])
+            av_custom_attributes.update({
+                CUST_ATTR_KEY_SERVER_ID: version_entity["id"],
+                CUST_ATTR_KEY_SERVER_PATH: version_path,
+            })
 
         base_component_item = {
             "assettype_data": {


### PR DESCRIPTION
## Description
Fill AYON id on integrated AssetVersion on ftrack.

## Testing notes
This PR is related only to client code.
1. Use dev bundle or create package and make sure code from this branch is used.
2. Enable frack addon...
3. Launch host of your choice.
4. Create and publish something that will integrated to ftrack (based on settings of Collect Ftrack Family).
5. After integration go to ftrack, show details of integrated version and it should have filled AYON id with version id in AYON.
6. To make sure it is version id (and not folder id) call this in Tray > Admin > Console
```python
import ayon_api

project_name = "<your project>"
version_id = "<id value from AssetVersion on ftrack>"
print(ayon_api.get_version_by_id(project_name, version_id))
"""
Should print entity data, not `None`.