### PR TITLE
PrepareProject: Fix custom attribute list values

### DIFF
--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -565,9 +565,13 @@ class PrepareProjectServer(ServerAction):
             )
             return None
 
+        attr_config_data = attr_config["data"]
+        if isinstance(attr_config_data, str):
+            attr_config_data = json.loads(attr_config_data)
+
         available_values = {
             item["value"]
-            for item in attr_config["data"]
+            for item in attr_config_data
         }
         new_value = [
             item

--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -82,7 +82,7 @@ class PrepareProjectServer(ServerAction):
                 "label": item["label"],
                 "name": name,
                 "value": value in default
-           })
+            })
         output.append({
             "type": "hidden",
             "value": json.dumps(mapping),


### PR DESCRIPTION
## Description
Data of custom attribute definition were not converted from json string to data so prepare project action did crash in the middle of work.

### Testing notes
1. Create package from the package
2. Run both leecher and processor using service tools (`./service_tools/start.ps1 services`)
3. Run prepare project action on new project
4. It should finish fine