### PR TITLE
Integrate thumbnail if there are not reviewables

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -204,6 +204,7 @@ class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
         thumbnail_data_items = []
 
         # Create thumbnail components
+        thumbnail_item = None
         for repre in thumbnail_representations:
             # get repre path from representation
             # and return published_path if available
@@ -365,6 +366,9 @@ class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
                     os.path.splitext(filename)[0]
                 )
                 component_list.append(origin_name_component)
+
+        if not review_representations and thumbnail_item:
+            component_list.append(thumbnail_item)
 
         # Add others representations as component
         for repre in other_representations:


### PR DESCRIPTION
## Description
Integretate thumbnail if there are not reviewables.

## Testing notes
1. Make an instance that does not create reviewable (e.g. model in traypublisher) and add a thumbnail to the instance.
2. Publish. The instance must have assigned ftrack family (based on collect ftrack family).
3. The thumbnail should be on ftrack.