### PR TITLE
Processor: Download event handlers from addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,46 @@ As mentioned there are 2 services `leecher` and `processor`. Both services have 
 
 To run services locally (recommended only for development purposes), there are 2 possible approaches. One is by running docker image, or using prepared service tools.
 
+- `leecher` - Service that listens to ftrack events and stores them in the AYON database.
+- `processor` - Service that is processing ftrack events stored in the AYON database. Only one event is processed at a time.
+
+### Processor
+Processor contains multiple event handlers that handle synchronization or basic automations helpers. It also provides a way to add custom event handlers from other addons. The addon must be loaded into the server, and must be available in bundle based on variant that service is running in ("production", "staging" or dev bundle).
+The addon also must have prepared archive file that can be downloaded from the server.
+
+#### Archive file
+The archive file can be a zip or tar, must contain `manifest.json` file that describes the content. The archive file must be uploaded to the server and must be available for download. The addon must implement `get_custom_ftrack_handlers_endpoint` method that returns URL to the archive file.
+
+```python
+class SomeAddon(BaseServerAddon):
+    name = "some_addon"
+    version = "1.0.0"
+    
+    def get_custom_ftrack_handlers_endpoint(self) -> str:
+        return "addons/{self.name}/{self.version}/private/ftrack_handlers.tar.gz"
+```
+
+#### Manifest file
+Manifest file is a JSON file that describes the content of the archive file. It is used to load the content of the archive file into the processor. The file must be named `manifest.json` and must be in the root of the archive file.
+
+```json
+{
+    "version": "1.0.0",
+    "handler_subfolders": [
+        "event_handlers"
+    ],
+    "python_path_subfolders": [
+        "common"
+    ]
+}
+```
+Content of manifect may change in future, to be able to track changes and keep backwards compatibilit a `"version"` was added. Current version is `"1.0.0"`.
+
+<b>1.0.0</b>
+- `handler_subfolders` - List of subfolder, relative to manifest.json where files with event handlers can be found. Processor will go through all of the subfolders and import all python files that are in the subfolder. It is recommended to have only one subfolder.
+- `python_path_subfolders` - Optional list of subfolders, relative to manifest.json. These paths are added to `sys.path` so content inside can be imported. Can be used for "common" code for the event handlers. It is not recommended to add python modules because of possible conflicts with other addons, but is possible.
+
+
 ### Start as docker
 Both services have prepared scripts to build and run docker images. There are 2 scripts `manage.ps1` for Windows and `Makefile` for Linux. Both scripts are doing the same thing and have same commands.
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,6 +2,7 @@ from typing import Type, Any
 
 import semver
 from fastapi import Query
+from nxtools import logging
 
 from ayon_server.addons import BaseServerAddon, AddonLibrary
 from ayon_server.lib.postgres import Postgres
@@ -86,9 +87,16 @@ class FtrackAddon(BaseServerAddon):
             addon = addons_mapping.get(addon_version)
             if not hasattr(addon, "get_custom_ftrack_handlers_endpoint"):
                 continue
-            endpoint = addon.get_custom_ftrack_handlers_endpoint()
-            if endpoint:
-                endpoints.append(endpoint)
+            try:
+                endpoint = addon.get_custom_ftrack_handlers_endpoint()
+                if endpoint:
+                    endpoints.append(endpoint)
+            except BaseException as exc:
+                logging.warning(
+                    f"Failed to receive ftrack handlers from addon"
+                    f" {addon_name} {addon_version}. {exc}"
+                )
+
         return output
 
     async def _empty_create_ftrack_attributes(self):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,5 +1,7 @@
-import semver
 from typing import Type, Any
+
+import semver
+from fastapi import Query
 
 from ayon_server.addons import BaseServerAddon, AddonLibrary
 from ayon_server.lib.postgres import Postgres
@@ -43,6 +45,51 @@ class FtrackAddon(BaseServerAddon):
         need_restart = await self.create_ftrack_attributes()
         if need_restart:
             self.request_server_restart()
+
+    def initialize(self) -> None:
+        self.add_endpoint(
+            "/customProcessorHandlers",
+            self.get_custom_processor_handlers,
+            method="GET",
+        )
+
+    async def get_custom_processor_handlers(
+        self,
+        variant: str = Query("production"),
+    ) -> {}:
+        bundles = await Postgres.fetch(
+            "SELECT name, is_production, is_staging, is_dev, data->'addons' as addons FROM bundles"
+        )
+        bundles_by_variant = {
+            "production": None,
+            "staging": None
+        }
+        for bundle in bundles:
+            if bundle["is_dev"]:
+                bundles_by_variant[bundle["name"]] = bundle
+                continue
+
+            if bundle["is_production"]:
+                bundles_by_variant["production"] = bundle
+
+            if bundle["is_staging"]:
+                bundles_by_variant["staging"] = bundle
+
+        endpoints = []
+        output = {"endpoints": endpoints}
+        if variant not in bundles_by_variant:
+            return output
+        addons = bundles_by_variant[variant]["addons"]
+        addon_library = AddonLibrary.getinstance()
+        for addon_name, addon_version in addons.items():
+            addons_mapping = addon_library.get(addon_name) or {}
+            addon = addons_mapping.get(addon_version)
+            if not hasattr(addon, "get_custom_ftrack_handlers_endpoint"):
+                continue
+            endpoint = addon.get_custom_ftrack_handlers_endpoint()
+            if endpoint:
+                endpoints.append(endpoint)
+        return output
 
     async def _empty_create_ftrack_attributes(self):
         return False

--- a/service_tools/.gitignore
+++ b/service_tools/.gitignore
@@ -1,2 +1,3 @@
 venv/*
 .env
+downloads/*

--- a/service_tools/main.py
+++ b/service_tools/main.py
@@ -4,12 +4,14 @@ import logging
 import argparse
 import subprocess
 import time
+import platform
 
 from ayon_api.constants import (
     DEFAULT_VARIANT_ENV_KEY,
 )
 
-ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+ADDON_DIR = os.path.dirname(CURRENT_DIR)
 
 
 def run_both():
@@ -64,6 +66,13 @@ def main():
     opts = parser.parse_args()
     if opts.variant:
         os.environ[DEFAULT_VARIANT_ENV_KEY] = opts.variant
+
+    # Set download root for service tools inside service tools
+    download_root = os.getenv("AYON_FTRACK_DOWNLOAD_ROOT")
+    if not download_root:
+        os.environ["AYON_FTRACK_DOWNLOAD_ROOT"] = os.path.join(
+            CURRENT_DIR, "downloads"
+        )
 
     service_name = opts.service
     if service_name == "both":

--- a/services/processor/processor/download_utils.py
+++ b/services/processor/processor/download_utils.py
@@ -1,0 +1,257 @@
+import os
+import sys
+import shutil
+import uuid
+import contextlib
+import threading
+import time
+import json
+import tarfile
+import zipfile
+
+import appdirs
+import ayon_api
+
+IMPLEMENTED_ARCHIVE_FORMATS = {
+    ".zip", ".tar", ".tgz", ".tar.gz", ".tar.xz", ".tar.bz2"
+}
+PROCESS_ID = uuid.uuid4().hex
+# Wait 1 hour before cleaning up download dir
+# - Running process should update lock file every 1 second
+_LOCK_CLEANUP_TIME = 60 * 60
+
+
+def get_download_root():
+    root = os.getenv("AYON_FTRACK_DOWNLOAD_ROOT")
+    if not root:
+        root = os.path.join(
+            appdirs.user_data_dir("ayon-ftrack", "Ynput"),
+            "downloads"
+        )
+    return root
+
+
+def get_archive_ext_and_type(archive_file):
+    """Get archive extension and type.
+
+    Args:
+        archive_file (str): Path to archive file.
+
+    Returns:
+        Tuple[str, str]: Archive extension and type.
+    """
+
+    tmp_name = archive_file.lower()
+    if tmp_name.endswith(".zip"):
+        return ".zip", "zip"
+
+    for ext in (
+        ".tar",
+        ".tgz",
+        ".tar.gz",
+        ".tar.xz",
+        ".tar.bz2",
+    ):
+        if tmp_name.endswith(ext):
+            return ext, "tar"
+
+    return None, None
+
+
+def extract_archive_file(archive_file, dst_folder=None):
+    """Extract archived file to a directory.
+
+    Args:
+        archive_file (str): Path to a archive file.
+        dst_folder (Optional[str]): Directory where content will be extracted.
+            By default, same folder where archive file is.
+    """
+
+    if not dst_folder:
+        dst_folder = os.path.dirname(archive_file)
+
+    archive_ext, archive_type = get_archive_ext_and_type(archive_file)
+
+    print(f"Extracting {archive_file} -> {dst_folder}")
+    if archive_type is None:
+        _, ext = os.path.splitext(archive_file)
+        raise ValueError((
+            f"Invalid file extension \"{ext}\"."
+            f" Expected {', '.join(IMPLEMENTED_ARCHIVE_FORMATS)}"
+        ))
+
+    if archive_type == "zip":
+        with zipfile.ZipFile(archive_file) as zip_file:
+            zip_file.extractall(dst_folder)
+
+    elif archive_type == "tar":
+        if archive_ext == ".tar":
+            tar_type = "r:"
+        elif archive_ext.endswith(".xz"):
+            tar_type = "r:xz"
+        elif archive_ext.endswith(".gz"):
+            tar_type = "r:gz"
+        elif archive_ext.endswith(".bz2"):
+            tar_type = "r:bz2"
+        else:
+            tar_type = "r:*"
+
+        with tarfile.open(archive_file, tar_type) as tar_file:
+            tar_file.extractall(dst_folder)
+
+
+class _LockThread(threading.Thread):
+    def __init__(self, lock_file):
+        super().__init__()
+        self.lock_file = lock_file
+        self._event = threading.Event()
+        self.interval = 1
+
+    def stop(self):
+        if not self._event.is_set():
+            self._event.set()
+
+    def run(self):
+        with open(self.lock_file, "w") as stream:
+            while not self._event.wait(self.interval):
+                stream.seek(0)
+                stream.write(str(time.time()))
+                stream.flush()
+
+
+@contextlib.contextmanager
+def _lock_file_update(lock_file):
+    thread = _LockThread(lock_file)
+    thread.start()
+    try:
+        yield
+    finally:
+        thread.stop()
+        thread.join()
+
+
+def _download_event_handlers(dirpath, custom_handlers, event_handler_dirs):
+    for custom_handler in custom_handlers:
+        addon_name = custom_handler["addon_name"]
+        addon_version = custom_handler["addon_version"]
+        endpoint = custom_handler["endpoint"]
+        filename = endpoint.rsplit("/")[-1]
+        path = os.path.join(dirpath, filename)
+        url = "/".join([ayon_api.get_base_url(), endpoint])
+        try:
+            ayon_api.download_file(url, path)
+
+        except BaseException as exc:
+            print(
+                "Failed to download event handlers"
+                f" for {addon_name} {addon_version}"
+                f"from '{endpoint}'. Reason: {exc}"
+            )
+            continue
+
+        try:
+            # Create temp dir for event handlers
+            subdir = f"{addon_name}_{addon_version}"
+            extract_dir = os.path.join(dirpath, subdir)
+            # Extract downloaded archive
+            extract_archive_file(path, extract_dir)
+            manifest_file = os.path.join(extract_dir, "manifest.json")
+            if not os.path.exists(manifest_file):
+                print(
+                    f"Manifest file not found in"
+                    f" downloaded archive from {endpoint}"
+                )
+                continue
+
+            with open(manifest_file, "r") as stream:
+                manifest = json.load(stream)
+
+            manifest_version = manifest["version"]
+            maj_v, min_v, patch_v = (
+                int(part) for part in manifest_version.split(".")
+            )
+            if (maj_v, min_v, patch_v) > (1, 0, 0):
+                print(
+                    f"Manifest file has unknown version {manifest_version}."
+                    " Trying to process it anyway."
+                )
+                continue
+
+            for even_handler_subpath in manifest.get("handler_subfolders", []):
+                # Add path to event handler dirs
+                event_handler_dirs.append(os.path.join(
+                    extract_dir, even_handler_subpath
+                ))
+
+            for python_subpath in manifest.get("python_path_subfolders", []):
+                python_dir = os.path.join(extract_dir, python_subpath)
+                sys.path.insert(0, python_dir)
+
+        except BaseException as exc:
+            print(f"Failed to extract downloaded archive: {exc}")
+
+        finally:
+            # Remove archive
+            os.remove(path)
+
+
+@contextlib.contextmanager
+def downloaded_event_handlers(custom_handlers):
+    event_handler_dirs = []
+    if not custom_handlers:
+        yield event_handler_dirs
+        return
+
+    root = get_download_root()
+    dirpath = os.path.join(root, PROCESS_ID)
+    os.makedirs(dirpath, exist_ok=True)
+
+    lock_file = os.path.join(dirpath, "lock")
+    try:
+        with _lock_file_update(lock_file):
+            print("Downloading event handlers...")
+            _download_event_handlers(
+                dirpath, custom_handlers, event_handler_dirs
+            )
+            yield event_handler_dirs
+    finally:
+        shutil.rmtree(dirpath)
+        print("downloaded_event_handlers end")
+
+
+def cleanup_download_root():
+    root = get_download_root()
+    if not os.path.exists(root):
+        return
+
+    current_time = time.time()
+    paths_to_remove = []
+    for subdir in os.listdir(root):
+        path = os.path.join(root, subdir)
+        if not os.path.isdir(path):
+            continue
+        lock_file = os.path.join(path, "lock")
+        if not os.path.exists(lock_file):
+            paths_to_remove.append(path)
+            continue
+
+        try:
+            with open(lock_file, "r") as stream:
+                content = stream.read()
+
+        except BaseException:
+            print(
+                "Failed to read lock file to check"
+                f" if can remove downloaded content '{lock_file}'"
+            )
+            continue
+
+        last_update = 0
+        if content:
+            last_update = float(content)
+        if (current_time - last_update) > _LOCK_CLEANUP_TIME:
+            paths_to_remove.append(path)
+
+    for path in paths_to_remove:
+        print(f"Cleaning up download directory: {path}")
+        shutil.rmtree(path)


### PR DESCRIPTION
## Description
Ftrack processor is able to download service event handlers from other addons.

## Additional information
Ftrack addon allows an addon to define it's custom service handlers by implementing `get_custom_ftrack_handlers_endpoint` returning endpoint leading to file on AYON server.

Processor will use always current production, staging or dev bundle addons (based on used variant in service).

The files are by default stored to appdirs, download root can be changed by env variable. But it will always generate random process id under which are stored the files so it is possible to run multiple processes (or re-use the same docker image). Implemented basic cleanup strategy to remove 1 hour inactive folders.