### PR TITLE
Attribute permissions: Allow to change AYON ID and path to anyone

### DIFF
--- a/server/settings/custom_attributes.py
+++ b/server/settings/custom_attributes.py
@@ -142,20 +142,14 @@ DEFAULT_CUSTOM_ATTRIBUTES_SETTINGS = {
             ]
         },
         "ayon_id": {
-            "write_security_roles": [
-                "API",
-                "Administrator"
-            ],
+            "write_security_roles": [],
             "read_security_roles": [
                 "API",
                 "Administrator"
             ]
         },
         "ayon_path": {
-            "write_security_roles": [
-                "API",
-                "Administrator"
-            ],
+            "write_security_roles": [],
             "read_security_roles": [
                 "API",
                 "Administrator"


### PR DESCRIPTION
# Description
Change write permissions of AYON id and AYON path to be empty -> any user can change them.

## Additional information
The attributes are filled during publishing on version entity, but if users don't have permissions it just silently logs error without doing it.

### Note
This opens possible hell by giving artist permissions to change backend attribute. Maybe we should find better approach how to achieve this in future? Not sure how exactly, maybe by using event system?

## Testing notes
Testing requires to have artist user on ftrack without admin permissions.
1. Run tray as admin.
2. Run Create/Update custom attributes action on ftrack to update attributes permissions.
3. Run tray with ftrack user that does not have admin nor API permissions.
4. Publish something.
5. AYON id and AYON path should be filled and Publisher should not show errors for Integrate ftrack plugin.