### PR TITLE
Settings: Fix attribute name of default read roles attribute

### DIFF
--- a/server/settings/custom_attributes.py
+++ b/server/settings/custom_attributes.py
@@ -6,7 +6,7 @@ class CustomAttributeModel(BaseSettingsModel):
         default_factory=list,
         title="Write roles",
     )
-    read_roles: list[str] = SettingsField(
+    read_security_roles: list[str] = SettingsField(
         default_factory=list,
         title="Read roles",
     )


### PR DESCRIPTION
## Description
For some reason there is defined attribute name `read_roles` instead of `read_security_roles` so any settings for read roles are not propagated during Create/Update custom attributes.