### PR TITLE
Service processor: Cleanup process on fail

### DIFF
--- a/services/processor/processor/ftrack_session.py
+++ b/services/processor/processor/ftrack_session.py
@@ -72,6 +72,7 @@ class ProcessEventHub(ftrack_api.event.hub.EventHub):
         started = time.time()
         while True:
             job = None
+            empty_queue = False
             try:
                 item = self._event_queue.get(timeout=0.1)
                 if isinstance(item, tuple):
@@ -80,6 +81,11 @@ class ProcessEventHub(ftrack_api.event.hub.EventHub):
                     event = item
 
             except queue.Empty:
+                empty_queue = True
+
+            # Do not do this under except handling to avoid confusing
+            #   traceback if something happens
+            if empty_queue:
                 if not self.load_event_from_jobs():
                     time.sleep(0.1)
                 continue

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -171,8 +171,6 @@ def _cleanup_process():
         if isinstance(thread, threading.Timer):
             thread.cancel()
 
-    sys.exit(0)
-
 
 def main():
     logging.basicConfig(level=logging.INFO)
@@ -197,9 +195,12 @@ def main():
     # Register interrupt signal
     def signal_handler(sig, frame):
         _cleanup_process()
+        sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     atexit.register(_cleanup_process)
-
-    main_loop()
+    try:
+        main_loop()
+    finally:
+        _cleanup_process()

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -159,6 +159,10 @@ def main_loop():
 def _cleanup_process():
     """Cleanup timer threads on exit."""
     print("Process stop requested. Terminating process.")
+    for thread in threading.enumerate():
+        if isinstance(thread, threading.Timer):
+            thread.cancel()
+
     if not _GlobalContext.stop_event.is_set():
         _GlobalContext.stop_event.set()
     session = _GlobalContext.session
@@ -166,10 +170,6 @@ def _cleanup_process():
         if session.event_hub.connected is True:
             session.event_hub.disconnect()
         session.close()
-
-    for thread in threading.enumerate():
-        if isinstance(thread, threading.Timer):
-            thread.cancel()
 
 
 def main():

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -173,7 +173,7 @@ def _cleanup_process():
 
 
 def main():
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
 
     try:
         ayon_api.init_service()

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -88,14 +88,16 @@ def create_session():
 
     session = _GlobalContext.session
     if session is not None:
-        print("Created ftrack session")
+        logging.info("Created ftrack session")
         return session
 
     if not error_message:
         error_message = error_summary
-    print(error_message)
+
+    log_msg = error_message
     if tb_content:
-        print(tb_content)
+        log_msg += f"\n{tb_content}"
+    logging.error(log_msg)
     if (
         (tb_content is not None and _GlobalContext.session_fail_logged == 2)
         or (tb_content is None and _GlobalContext.session_fail_logged == 1)
@@ -152,20 +154,26 @@ def main_loop():
         handler_paths = get_handler_paths()
         with downloaded_event_handlers(custom_handlers) as custom_handler_dirs:
             handler_paths.extend(custom_handler_dirs)
+            logging.info("Starting listen server")
             server = FtrackServer(handler_paths)
             server.run_server(session)
+        logging.info("Server stopped.")
+    logging.info("Main loop stopped.")
 
 
 def _cleanup_process():
     """Cleanup timer threads on exit."""
-    print("Process stop requested. Terminating process.")
+    logging.info("Process stop requested. Terminating process.")
+    logging.debug("Canceling threading timers.")
     for thread in threading.enumerate():
         if isinstance(thread, threading.Timer):
             thread.cancel()
 
+    logging.debug("Stopping main loop.")
     if not _GlobalContext.stop_event.is_set():
         _GlobalContext.stop_event.set()
     session = _GlobalContext.session
+    logging.debug("Closing ftrack session.")
     if session is not None:
         if session.event_hub.connected is True:
             session.event_hub.disconnect()
@@ -182,7 +190,7 @@ def main():
         connected = False
 
     if not connected:
-        print("Failed to connect to AYON server.")
+        logging.warning("Failed to connect to AYON server.")
         # Sleep for 10 seconds, so it is possible to see the message in
         #   docker
         # NOTE: Becuase AYON connection failed, there's no way how to log it
@@ -190,7 +198,7 @@ def main():
         time.sleep(10)
         sys.exit(1)
 
-    print("Connected to AYON server.")
+    logging.info("Connected to AYON server.")
 
     # Register interrupt signal
     def signal_handler(sig, frame):

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -164,16 +164,16 @@ def main_loop():
 def _cleanup_process():
     """Cleanup timer threads on exit."""
     logging.info("Process stop requested. Terminating process.")
-    logging.debug("Canceling threading timers.")
+    logging.info("Canceling threading timers.")
     for thread in threading.enumerate():
         if isinstance(thread, threading.Timer):
             thread.cancel()
 
-    logging.debug("Stopping main loop.")
+    logging.info("Stopping main loop.")
     if not _GlobalContext.stop_event.is_set():
         _GlobalContext.stop_event.set()
     session = _GlobalContext.session
-    logging.debug("Closing ftrack session.")
+    logging.info("Closing ftrack session.")
     if session is not None:
         if session.event_hub.connected is True:
             session.event_hub.disconnect()
@@ -181,7 +181,7 @@ def _cleanup_process():
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
 
     try:
         ayon_api.init_service()


### PR DESCRIPTION
## Changelog Description
Run cleanup process functionality on crash. Which is potential fix of stuck processor event.

## Additional info
It was reported multiple times that events are not actually processed, but service in web ui is shows as "running". Only service restart helps to resolve the issue. Changes here makes sure that cleanup of process happens when process crashes, not just when is terminated. Hopefully will resolve the issue.

Cleanup process funcationlity stops running threading timers. They can cause that the process is stuck.

## Testing notes:
I couldn't replicate the issue so I don't know how to test. For now:
1. Start services.
2. They should work as before.
