### PR TITLE
Event handlers: Status task to version settings

### DIFF
--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -88,8 +88,8 @@ class SyncStatusTaskToVersion(BaseSettingsModel):
         title="Status mapping",
         default_factory=list,
     )
-    asset_types_to_skip: list[str] = SettingsField(
-        title="Skip on Asset types (short)",
+    asset_types_filter: list[str] = SettingsField(
+        title="Asset types (short)",
         default_factory=list,
     )
 


### PR DESCRIPTION
## Changelog Description
Fix attribute name in settings model.

## Additional info
Status to version settings model has correct attribute name `asset_types_filter` instead of `asset_types_to_skip`.

## Testing notes:
1. Task to version status propagation works.