### PR TITLE
Updated settings variable as per the defaults in the same file

### DIFF
--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -88,7 +88,7 @@ class SyncStatusTaskToVersion(BaseSettingsModel):
         title="Status mapping",
         default_factory=list,
     )
-    asset_types_to_skip: list[str] = SettingsField(
+    asset_types_filter: list[str] = SettingsField(
         title="Skip on Asset types (short)",
         default_factory=list,
     )


### PR DESCRIPTION
Updated settings variable as per the defaults in the same file which would cause a KeyError on line 148 in event_task_to_version_status.py when not setup

## Changelog Description

From:
```python
    asset_types_to_skip: list[str] = SettingsField(
        title="Skip on Asset types (short)",
        default_factory=list,
    )
```

To:
```python
    asset_types_filter: list[str] = SettingsField(
        title="Skip on Asset types (short)",
        default_factory=list,
    )
```

## Additional info
The defaults `DEFAULT_SERVICE_HANDLERS_SETTINGS` dictate that the modified variable name should now be correct.


## Testing notes:

1. Configure addon
2. Sync
3. Encounter KeyError
