### PR TITLE
Status propagation: Better asset types filtering

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -7,7 +7,11 @@ from nxtools import logging
 from ayon_server.addons import BaseServerAddon, AddonLibrary
 from ayon_server.lib.postgres import Postgres
 
-from .settings import FtrackSettings, DEFAULT_VALUES
+from .settings import (
+    FtrackSettings,
+    DEFAULT_VALUES,
+    convert_settings_overrides,
+)
 from .constants import (
     FTRACK_ID_ATTRIB,
     FTRACK_PATH_ATTRIB,
@@ -194,40 +198,7 @@ class FtrackAddon(BaseServerAddon):
         source_version: str,
         overrides: dict[str, Any],
     ) -> dict[str, Any]:
-        self._convert_integrate_ftrack_status_settings(overrides)
-        # Use super conversion
+        convert_settings_overrides(source_version, overrides)
         return await super().convert_settings_overrides(
             source_version, overrides
         )
-
-    def _convert_integrate_ftrack_status_settings(self, overrides):
-        """Convert settings of 'IntegrateFtrackFarmStatus' profiles.
-
-        This change happened in 1.1.0 version of the addon, where the settings
-        were converted to use AYON naming convention over OpenPype convention.
-
-        Args:
-            overrides (dict[str, Any]): Settings overrides.
-        """
-        value = overrides
-        for key in (
-            "publish",
-            "IntegrateFtrackFarmStatus",
-            "farm_status_profiles",
-        ):
-            if not isinstance(value, dict) or key not in value:
-                return
-
-            value = value[key]
-
-        if not isinstance(value, list):
-            return
-
-        for profile in value:
-            for src_key, dst_key in (
-                ("hosts", "host_names"),
-                ("families", "product_types"),
-                ("subset_names", "product_names"),
-            ):
-                if src_key in profile:
-                    profile[dst_key] = profile.pop(src_key)

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -1,3 +1,4 @@
+from .conversions import convert_settings_overrides
 from .main import (
     FtrackSettings,
     DEFAULT_VALUES,
@@ -5,6 +6,8 @@ from .main import (
 
 
 __all__ = (
+    "convert_settings_overrides",
+
     "FtrackSettings",
     "DEFAULT_VALUES",
 )

--- a/server/settings/conversions.py
+++ b/server/settings/conversions.py
@@ -34,6 +34,36 @@ def _convert_integrate_ftrack_status_settings(overrides):
                 profile[dst_key] = profile.pop(src_key)
 
 
+def _convert_task_to_version_status_mapping_1_2_0(overrides):
+    value = overrides
+    for key in (
+        "service_event_handlers",
+        "status_task_to_version",
+    ):
+        value = value.get(key)
+        if not value:
+            return
+
+    if "asset_types_filter" in value:
+        value["asset_types"] = value.pop("asset_types_filter")
+        value["asset_types_filter_type"] = "allow_list"
+
+
+def _convert_version_to_task_status_mapping_1_2_0(overrides):
+    value = overrides
+    for key in (
+        "service_event_handlers",
+        "status_version_to_task",
+    ):
+        value = value.get(key)
+        if not value:
+            return
+
+    if "asset_types_to_skip" in value:
+        value["asset_types"] = value.pop("asset_types_to_skip")
+        value["asset_types_filter_type"] = "deny_list"
+
+
 def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],

--- a/server/settings/conversions.py
+++ b/server/settings/conversions.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+
+def _convert_integrate_ftrack_status_settings(overrides):
+    """Convert settings of 'IntegrateFtrackFarmStatus' profiles.
+
+    This change happened in 1.1.0 version of the addon, where the settings
+    were converted to use AYON naming convention over OpenPype convention.
+
+    Args:
+        overrides (dict[str, Any]): Settings overrides.
+    """
+    value = overrides
+    for key in (
+        "publish",
+        "IntegrateFtrackFarmStatus",
+        "farm_status_profiles",
+    ):
+        if not isinstance(value, dict) or key not in value:
+            return
+
+        value = value[key]
+
+    if not isinstance(value, list):
+        return
+
+    for profile in value:
+        for src_key, dst_key in (
+            ("hosts", "host_names"),
+            ("families", "product_types"),
+            ("subset_names", "product_names"),
+        ):
+            if src_key in profile:
+                profile[dst_key] = profile.pop(src_key)
+
+
+def convert_settings_overrides(
+    source_version: str,
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    _convert_integrate_ftrack_status_settings(overrides)
+    _convert_task_to_version_status_mapping_1_2_0(overrides)
+    _convert_version_to_task_status_mapping_1_2_0(overrides)
+    return overrides

--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -435,7 +435,7 @@ DEFAULT_SERVICE_HANDLERS_SETTINGS = {
     "status_task_to_version": {
         "enabled": True,
         "mapping": [],
-        "asset_types_filter": []
+        "asset_types_to_skip": []
     },
     "status_version_to_task": {
         "enabled": True,

--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -98,7 +98,7 @@ class SyncStatusTaskToVersion(BaseSettingsModel):
     asset_types_filter_type: str = SettingsField(
         title="Asset types Allow/Deny",
         default="allow_list",
-        enum=_allow_deny_enum,
+        enum_resolver=_allow_deny_enum,
     )
     asset_types: list[str] = SettingsField(
         title="Asset types (short)",
@@ -123,7 +123,7 @@ class SyncStatusVersionToTask(BaseSettingsModel):
     asset_types_filter_type: str = SettingsField(
         title="Asset types Allow/Deny",
         default="deny_list",
-        enum=_allow_deny_enum,
+        enum_resolver=_allow_deny_enum,
     )
     asset_types: list[str] = SettingsField(
         title="Asset types (short)",

--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -81,6 +81,13 @@ class SyncStatusTaskToParent(BaseSettingsModel):
     )
 
 
+def _allow_deny_enum():
+    return [
+        {"value": "allow_list", "label": "Allow list"},
+        {"value": "deny_list", "label": "Deny list"}
+    ]
+
+
 class SyncStatusTaskToVersion(BaseSettingsModel):
     _isGroup = True
     enabled: bool = True
@@ -88,8 +95,13 @@ class SyncStatusTaskToVersion(BaseSettingsModel):
         title="Status mapping",
         default_factory=list,
     )
-    asset_types_to_skip: list[str] = SettingsField(
-        title="Skip on Asset types (short)",
+    asset_types_filter_type: str = SettingsField(
+        title="Asset types Allow/Deny",
+        default="allow_list",
+        enum=_allow_deny_enum,
+    )
+    asset_types: list[str] = SettingsField(
+        title="Asset types (short)",
         default_factory=list,
     )
 
@@ -108,8 +120,13 @@ class SyncStatusVersionToTask(BaseSettingsModel):
         title="Status mapping",
         default_factory=list,
     )
-    asset_types_to_skip: list[str] = SettingsField(
-        title="Skip on Asset types (short)",
+    asset_types_filter_type: str = SettingsField(
+        title="Asset types Allow/Deny",
+        default="deny_list",
+        enum=_allow_deny_enum,
+    )
+    asset_types: list[str] = SettingsField(
+        title="Asset types (short)",
         default_factory=list,
     )
 
@@ -435,12 +452,14 @@ DEFAULT_SERVICE_HANDLERS_SETTINGS = {
     "status_task_to_version": {
         "enabled": True,
         "mapping": [],
-        "asset_types_to_skip": []
+        "asset_types_filter_type": "allow_list",
+        "asset_types": []
     },
     "status_version_to_task": {
         "enabled": True,
         "mapping": [],
-        "asset_types_to_skip": []
+        "asset_types_filter_type": "deny_list",
+        "asset_types": []
     },
     "next_task_update": {
         "enabled": True,

--- a/services/processor/processor/default_handlers/event_next_task_update.py
+++ b/services/processor/processor/default_handlers/event_next_task_update.py
@@ -129,9 +129,10 @@ class NextTaskUpdate(BaseEventHandler):
             ))
             return
 
-        mod_mapping = {}
-        for item in event_settings["mapping"]:
-            mod_mapping[item["name"]] = item["value"]
+        mod_mapping = {
+            item["name"]: item["value"]
+            for item in event_settings["mapping"]
+        }
         event_settings["mapping"] = mod_mapping
 
         statuses = session.query("Status").all()

--- a/services/processor/processor/default_handlers/event_task_to_version_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_version_status.py
@@ -123,29 +123,29 @@ class TaskToVersionStatus(BaseEventHandler):
             ["service_event_handlers"]
             [self.settings_key]
         )
-        mod_mapping = {}
-        for item in event_settings["mapping"]:
-            mod_mapping[item["name"]] = item["value"]
-        event_settings["mapping"] = mod_mapping
-        _status_mapping = event_settings["mapping"]
         if not event_settings["enabled"]:
             self.log.debug("Project \"{}\" has disabled {}.".format(
                 project_name, self.__class__.__name__
             ))
             return
 
-        if not _status_mapping:
+        status_mapping = {
+            item["name"].lower(): item["value"]
+            for item in event_settings["mapping"]
+        }
+        if not status_mapping:
             self.log.debug((
                 "Project \"{}\" does not have set status mapping for {}."
             ).format(project_name, self.__class__.__name__))
             return
 
-        status_mapping = {
-            key.lower(): value
-            for key, value in _status_mapping.items()
+        asset_type_filter = event_settings["asset_types_filter_type"]
+        is_allow_list = asset_type_filter == "allow_list"
+        asset_type_names = {
+            asset_type_name.lower()
+            for asset_type_name in event_settings["asset_types"]
+            if asset_type_name
         }
-
-        asset_types_to_skip = event_settings["asset_types_to_skip"]
 
         task_ids = [
             entity_info["entityId"]
@@ -154,7 +154,7 @@ class TaskToVersionStatus(BaseEventHandler):
 
         last_asset_versions_by_task_id = (
             self.find_last_asset_versions_for_task_ids(
-                session, task_ids, asset_types_to_skip
+                session, task_ids, is_allow_list, asset_type_names
             )
         )
 
@@ -173,9 +173,10 @@ class TaskToVersionStatus(BaseEventHandler):
         if not task_entities:
             return
 
-        status_ids = set()
-        for task_entity in task_entities:
-            status_ids.add(task_entity["status_id"])
+        status_ids = {
+            task_entity["status_id"]
+            for task_entity in task_entities
+        }
 
         task_status_entities = session.query(
             "select id, name from Status where id in ({})".format(
@@ -306,7 +307,7 @@ class TaskToVersionStatus(BaseEventHandler):
         return av_statuses_by_low_name, av_statuses_by_id
 
     def find_last_asset_versions_for_task_ids(
-        self, session, task_ids, asset_types_to_skip
+        self, session, task_ids, is_allow_list, asset_type_names
     ):
         """Find latest AssetVersion entities for task.
 
@@ -314,42 +315,61 @@ class TaskToVersionStatus(BaseEventHandler):
         same version for the task.
 
         Args:
-            asset_versions (list): AssetVersion entities sorted by "version".
-            task_ids (list): Task ids.
-            asset_types_to_skip (list): Asset types short names that will be
+            session (ftrack_api.Session): Ftrack session.
+            task_ids (list[str]): Task ids.
+            is_allow_list (bool): If True then asset_types are used
+                as allow list.
+            asset_type_names (set[str]): Asset types short names that will be
                 used to filter AssetVersions. Filtering is skipped if entered
                 value is empty list.
+
+        Returns:
+            dict[str, list[ftrack_api.Entity]]: Dictionary with task id as key
+                and list of AssetVersion entities as value.
+
         """
+        last_asset_versions_by_task_id = collections.defaultdict(list)
+
+        if not task_ids:
+            return last_asset_versions_by_task_id
+
+        if is_allow_list and not asset_type_names:
+            return last_asset_versions_by_task_id
 
         # Allow event only on specific asset type names
         asset_query_part = ""
-        if asset_types_to_skip:
+        if asset_type_names:
             # Query all AssetTypes
             asset_types = session.query(
                 "select id, short from AssetType"
             ).all()
             # Store AssetTypes by id
             asset_type_short_by_id = {
-                asset_type["id"]: asset_type["short"]
+                asset_type["id"]: asset_type["short"].lower()
                 for asset_type in asset_types
             }
 
             # Lower asset types from settings
-            # WARNING: not sure if is good idea to lower names as Ftrack may
-            #   contain asset type with name "Scene" and "scene"!
-            asset_types_to_skip_low = set(
-                asset_types_name.lower()
-                for asset_types_name in asset_types_to_skip
-            )
-            asset_type_ids = []
-            for type_id, short in asset_type_short_by_id.items():
-                # TODO log if asset type name is not found
-                if short.lower() not in asset_types_to_skip_low:
-                    asset_type_ids.append(type_id)
+            asset_type_ids = {
+                type_id
+                for type_id, short in asset_type_short_by_id.items()
+                if short.lower() in asset_type_names
+            }
 
-            # TODO log that none of asset type names were found in ftrack
-            if asset_type_ids:
+            # Allow list is enabled but asset type names are not available
+            if is_allow_list and not asset_type_ids:
+                self.log.warning((
+                    "None of asset type names were found in Ftrack."
+                    " Skipping filter."
+                ))
+                return last_asset_versions_by_task_id
+
+            if is_allow_list:
                 asset_query_part = " and asset.type_id in ({})".format(
+                    self.join_query_keys(asset_type_ids)
+                )
+            elif asset_type_ids:
+                asset_query_part = " and asset.type_id not in ({})".format(
                     self.join_query_keys(asset_type_ids)
                 )
 
@@ -360,7 +380,6 @@ class TaskToVersionStatus(BaseEventHandler):
             " order by version descending"
         ).format(self.join_query_keys(task_ids), asset_query_part)).all()
 
-        last_asset_versions_by_task_id = collections.defaultdict(list)
         last_version_by_task_id = {}
         not_finished_task_ids = set(task_ids)
         for asset_version in asset_versions:
@@ -381,7 +400,7 @@ class TaskToVersionStatus(BaseEventHandler):
             elif last_version > version:
                 # Skip processing if version is lower than last version
                 # and pop task id from `not_finished_task_ids`
-                not_finished_task_ids.remove(task_id)
+                not_finished_task_ids.discard(task_id)
                 continue
 
             # Add AssetVersion entity to output dictionary

--- a/services/processor/processor/default_handlers/event_task_to_version_status.py
+++ b/services/processor/processor/default_handlers/event_task_to_version_status.py
@@ -145,7 +145,7 @@ class TaskToVersionStatus(BaseEventHandler):
             for key, value in _status_mapping.items()
         }
 
-        asset_types_filter = event_settings["asset_types_filter"]
+        asset_types_to_skip = event_settings["asset_types_to_skip"]
 
         task_ids = [
             entity_info["entityId"]
@@ -154,7 +154,7 @@ class TaskToVersionStatus(BaseEventHandler):
 
         last_asset_versions_by_task_id = (
             self.find_last_asset_versions_for_task_ids(
-                session, task_ids, asset_types_filter
+                session, task_ids, asset_types_to_skip
             )
         )
 
@@ -306,7 +306,7 @@ class TaskToVersionStatus(BaseEventHandler):
         return av_statuses_by_low_name, av_statuses_by_id
 
     def find_last_asset_versions_for_task_ids(
-        self, session, task_ids, asset_types_filter
+        self, session, task_ids, asset_types_to_skip
     ):
         """Find latest AssetVersion entities for task.
 
@@ -316,14 +316,14 @@ class TaskToVersionStatus(BaseEventHandler):
         Args:
             asset_versions (list): AssetVersion entities sorted by "version".
             task_ids (list): Task ids.
-            asset_types_filter (list): Asset types short names that will be
+            asset_types_to_skip (list): Asset types short names that will be
                 used to filter AssetVersions. Filtering is skipped if entered
                 value is empty list.
         """
 
         # Allow event only on specific asset type names
         asset_query_part = ""
-        if asset_types_filter:
+        if asset_types_to_skip:
             # Query all AssetTypes
             asset_types = session.query(
                 "select id, short from AssetType"
@@ -337,14 +337,14 @@ class TaskToVersionStatus(BaseEventHandler):
             # Lower asset types from settings
             # WARNING: not sure if is good idea to lower names as Ftrack may
             #   contain asset type with name "Scene" and "scene"!
-            asset_types_filter_low = set(
+            asset_types_to_skip_low = set(
                 asset_types_name.lower()
-                for asset_types_name in asset_types_filter
+                for asset_types_name in asset_types_to_skip
             )
             asset_type_ids = []
             for type_id, short in asset_type_short_by_id.items():
                 # TODO log if asset type name is not found
-                if short.lower() in asset_types_filter_low:
+                if short.lower() not in asset_types_to_skip_low:
                     asset_type_ids.append(type_id)
 
             # TODO log that none of asset type names were found in ftrack


### PR DESCRIPTION
## Changelog Description
Added option to set Allow/Deny list of Asset types for "task to version status" and "version to task status" event handlers.

## Additional info
Enhance asset types filtering for the event handlers by allowing to change the filter type. Right now it can be only allow type for task to version and deny type for version to task which might be limiting.

## Testing notes:
1. Conversion of settings from previous versions should work (during copy settings).
2. Filtering set in settings works and statuses are changed accordingly.