### PR TITLE
Chore: Remove usage of 'intent' from default settings

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_note.py
@@ -31,7 +31,7 @@ class IntegrateFtrackNote(plugin.FtrackPublishInstancePlugin):
     # - Allows only `intent` and `comment` keys
     note_template = None
     # Backwards compatibility
-    note_with_intent_template = "{intent}: {comment}"
+    note_with_intent_template = "{comment}"
     # - note label must exist in Ftrack
     note_labels = []
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -597,7 +597,7 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "IntegrateFtrackNote": {
         "enabled": True,
-        "note_template": "{intent}: {comment}",
+        "note_template": "{comment}",
         "note_labels": []
     },
     "IntegrateFtrackDescription": {


### PR DESCRIPTION
## Changelog Description
Usage of `intent` key in tempaltes is removed by default.

## Additional info
Intent was available in pyblish pype but is not available in Publisher UI thus is not available for most of hosts and does not make sense to have it in default settings.

## Testing notes:
1. Validate changes in settings and default values.
