### PR TITLE
Sync: Sync start/end date and description

### DIFF
--- a/services/processor/processor/default_handlers/event_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_sync_from_ftrack.py
@@ -1331,15 +1331,26 @@ class SyncProcess:
                     task_type_changes[ftrack_id] = (entity, info)
 
                 default_attr_key = DEFAULT_ATTRS_MAPPING.get(key)
-                dst_key = key
+
                 if default_attr_key is not None:
                     dst_key = default_attr_key
                 elif key == CUST_ATTR_TOOLS:
                     dst_key = "tools"
+                else:
+                    dst_key = key
+
                 if dst_key not in entity.attribs:
                     continue
 
-                if default_attr_key is None and value is not None:
+                if default_attr_key is not None:
+                    if value is not None and key in ("startdate", "enddate"):
+                        date = arrow.get(value)
+                        # Shift date to 00:00:00 of the day
+                        # - ftrack is returning e.g. '2024-10-29T22:00:00'
+                        #  for '2024-10-30'
+                        value = str(date.shift(hours=24 - date.hour))
+
+                elif value is not None:
                     if key in FPS_KEYS:
                         value = convert_to_fps(value)
                     else:

--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -711,7 +711,7 @@ class SyncFromFtrack:
 
             for attr_name, value in (
                 ("startDate", ft_entity["start_date"]),
-                ("endtDate", ft_entity["end_date"]),
+                ("endDate", ft_entity["end_date"]),
                 ("description", ft_entity.get("description")),
             ):
                 if value is None or attr_name not in entity.attribs:

--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -308,7 +308,8 @@ class SyncFromFtrack:
 
         self.log.info("Querying project hierarchy from ftrack")
         ft_entities = ft_session.query((
-            "select id, name, parent_id, type_id, object_type_id"
+            "select id, name, parent_id, type_id, object_type_id, status_id"
+            ", start_date, end_date, description"  #, bid, status_id"
             " from TypedContext where project_id is \"{}\""
         ).format(ft_project["id"])).all()
         t_ft_entities_4 = time.perf_counter()
@@ -707,6 +708,16 @@ class SyncFromFtrack:
             ])
             entity.attribs[FTRACK_ID_ATTRIB] = ftrack_id
             entity.attribs[FTRACK_PATH_ATTRIB] = path
+
+            for attr_name, value in (
+                ("startDate", ft_entity["start_date"]),
+                ("endtDate", ft_entity["end_date"]),
+                ("description", ft_entity.get("description")),
+            ):
+                if value is None or attr_name not in entity.attribs:
+                    continue
+                entity.attribs[attr_name] = str(value)
+
             # ftrack id can not be available if ftrack entity was recreated
             #   during immutable entity processing
             attribute_values = cust_attr_value_by_entity_id[ftrack_id]

--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -3,6 +3,7 @@ import collections
 import time
 import logging
 
+import arrow
 from ayon_api import (
     get_project,
     create_project,
@@ -716,6 +717,13 @@ class SyncFromFtrack:
             ):
                 if value is None or attr_name not in entity.attribs:
                     continue
+
+                if isinstance(value, arrow.Arrow):
+                    # Shift date to 00:00:00 of the day
+                    # - ftrack is returning e.g. '2024-10-29T22:00:00'
+                    #  for '2024-10-30'
+                    value = str(value.shift(hours=24 - value.hour))
+
                 entity.attribs[attr_name] = str(value)
 
             # ftrack id can not be available if ftrack entity was recreated


### PR DESCRIPTION
## Changelog Description
Added sync of start/end date and description.

## Testing notes:
1. Start services.
2. Both action Sync to AYON and auto-sync should be able to sync start/end date and description.
