### PR TITLE
Sync: Folder and Task statuses

### DIFF
--- a/service_tools/requirements.txt
+++ b/service_tools/requirements.txt
@@ -7,7 +7,7 @@ colorama==0.4.6
 ftrack-python-api==2.3.3
 future==0.18.2
 idna==3.4
-ayon-python-api==1.0.0rc3
+ayon-python-api==1.0.10
 pydantic==1.10.2
 pyparsing==2.4.7
 python-dateutil==2.8.2

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ynput s.r.o. <info@ynput.io>"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.10"
-ayon-python-api = "1.0.0"
+ayon-python-api = "1.0.10"
 ftrack-python-api = "2.3.3"
 
 [tool.poetry.dev-dependencies]

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ynput s.r.o. <info@ynput.io>"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.10"
-ayon-python-api = "1.0.0"
+ayon-python-api = "1.0.10"
 ftrack-python-api = "2.3.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Changelog Description
First implementation of statuses sync for task and folder entities.

## Additional info
Because we don't sync statuses from ftrack to AYON we skip all status changes when the status is not available in AYON.

This PR requires ayon-python-api PR https://github.com/ynput/ayon-python-api/pull/188 so can't be tested right now.

## Testing notes:
1. Run services.
2. Sync a project, statuses from ftrack should be synced to AYON.
3. Change statuse on project with auto-sync, the change should be synced to AYON if status is available.
