### PR TITLE
Users: Sync users

### DIFF
--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -330,6 +330,10 @@ class FtrackServiceHandlers(BaseSettingsModel):
         title="Sync to AYON",
         default_factory=SimpleAction,
     )
+    sync_users_from_ftrack: SimpleAction = SettingsField(
+        title="Sync Users to AYON",
+        default_factory=SimpleAction,
+    )
     sync_hier_entity_attributes: SyncHierarchicalAttributes = SettingsField(
         title="Sync Hierarchical and Entity Attributes",
         default_factory=SyncHierarchicalAttributes,
@@ -389,6 +393,13 @@ DEFAULT_SERVICE_HANDLERS_SETTINGS = {
         ]
     },
     "sync_from_ftrack": {
+        "enabled": True,
+        "role_list": [
+            "Administrator",
+            "Project manager"
+        ]
+    },
+    "sync_users_from_ftrack": {
         "enabled": True,
         "role_list": [
             "Administrator",

--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -15,7 +15,7 @@ from ftrack_common import (
     get_ayon_attr_configs,
     query_custom_attribute_values,
 )
-from processor.lib import SyncFromFtrack
+from processor.lib import SyncFromFtrack, map_ftrack_users_to_ayon_users
 
 
 class PrepareProjectServer(ServerAction):
@@ -704,7 +704,19 @@ class PrepareProjectServer(ServerAction):
         anatomy_preset = event_values["anatomy_preset"]
         if anatomy_preset == self.default_preset_name:
             anatomy_preset = None
+        
+        ayon_users_to_clean_roles = self.get_ayon_users_to_clean_roles(
+            session, project_entity
+        )
+
         syncer.create_project(anatomy_preset, attributes)
+
+        for ayon_username in ayon_users_to_clean_roles:
+            user = ayon_api.get_user(ayon_username)
+            user_data = user["data"]
+            user_access_groups = user_data.setdefault("accessGroups", {})
+            user_access_groups[project_name] = []
+            ayon_api.patch(f"users/{ayon_username}", data=user_data)
 
         ayon_project = ayon_api.get_project(project_entity["full_name"])
         values = copy.deepcopy(ayon_project["attrib"])
@@ -748,3 +760,75 @@ class PrepareProjectServer(ServerAction):
             "message": "Project created in AYON.",
             "success": True
         }
+
+    def get_ayon_users_to_clean_roles(
+        self, session, project_entity
+    ):
+        """Get AYON usernames that should have removed roles from a project.
+
+        If project is private in ftrack we do remove roles from AYON users if
+        they should not see it.
+
+        Args:
+            session (ftrack_api.Session): ftrack session.
+            project_entity (ftrack_api.entity.base.Entity): Project entity.
+
+        """
+        if not project_entity["is_private"]:
+            return []
+
+        ayon_users = [
+            ayon_user
+            for ayon_user in ayon_api.get_users()
+            if (
+                not ayon_user["isAdmin"]
+                and not ayon_user["isManager"]
+                and not ayon_user["isService"]
+            )
+        ]
+        ayon_usernames = [
+            ayon_user["name"]
+            for ayon_user in ayon_users
+        ]
+
+        project_id = project_entity["id"]
+        role_ids = [
+            role["user_security_role_id"]
+            for role in session.query(
+                "select user_security_role_id"
+                " from UserSecurityRoleProject"
+                f" where project_id is '{project_id}'"
+            ).all()
+        ]
+        if not role_ids:
+            return ayon_usernames
+        joined_role_ids = self.join_filter_values(role_ids)
+        user_ids = {
+            role["user_id"]
+            for role in session.query(
+                "select user_id"
+                " from UserSecurityRole"
+                f" where security_role_id in ({joined_role_ids})"
+            ).all()
+        }
+        ftrack_users = []
+        if user_ids:
+            joined_user_ids = self.join_filter_values(user_ids)
+            ftrack_users = session.query(
+                "select id, username, email from User"
+                f" where id in ({joined_user_ids})"
+            ).all()
+        users_mapping = map_ftrack_users_to_ayon_users(
+            ftrack_users,
+            ayon_users
+        )
+
+        for ftrack_id, ayon_username in users_mapping.items():
+            if ayon_username is None:
+                continue
+
+            if ftrack_id not in user_ids:
+                ayon_usernames.remove(ayon_username)
+
+        return ayon_usernames
+

--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -704,7 +704,7 @@ class PrepareProjectServer(ServerAction):
         anatomy_preset = event_values["anatomy_preset"]
         if anatomy_preset == self.default_preset_name:
             anatomy_preset = None
-        
+
         ayon_users_to_clean_roles = self.get_ayon_users_to_clean_roles(
             session, project_entity
         )

--- a/services/processor/processor/default_handlers/action_sync_users.py
+++ b/services/processor/processor/default_handlers/action_sync_users.py
@@ -218,7 +218,7 @@ class SyncUsersFromFtrackAction(ServerAction):
                     attrib_diffs[key] = value
 
             if user_diffs:
-                ayon_api.put(
+                ayon_api.patch(
                     f"users/{ayon_user_name}",
                     **user_diffs,
                 )

--- a/services/processor/processor/default_handlers/action_sync_users.py
+++ b/services/processor/processor/default_handlers/action_sync_users.py
@@ -1,0 +1,306 @@
+import typing
+from typing import Union, List, Set, Dict, Any
+
+import ayon_api
+
+from ftrack_common import (
+    ServerAction,
+    get_service_ftrack_icon_url,
+)
+
+if typing.TYPE_CHECKING:
+    from ftrack_api.entity.user import User as FtrackUser
+    from ftrack_api.entity.base import Entity as FtrackEntity
+
+
+def map_ftrack_users_to_ayon_users(
+    ftrack_users: List["FtrackUser"],
+    ayon_users: List[Dict[str, Any]],
+) -> Dict[str, Union[str, None]]:
+    """Map ftrack users to AYON users.
+
+    Mapping is based on 2 possible keys, email and username where email has
+    higher priority. Once AYON user is mapped it cannot be mapped again to
+    different user.
+
+    Args:
+        ftrack_users (List[ftrack_api.entity.user.User]): List of ftrack users.
+        ayon_users (List[Dict[str, Any]]): List of AYON users.
+
+    Returns:
+        Dict[str, Union[str, None]]: Mapping of ftrack user id
+            to AYON username.
+
+    """
+    mapping: Dict[str, Union[str, None]] = {
+        user["id"]: None
+        for user in ftrack_users
+    }
+    ayon_users_by_email: Dict[str, str] = {}
+    ayon_users_by_name: Dict[str, str] = {}
+    for ayon_user in ayon_users:
+        ayon_name = ayon_user["name"]
+        ayon_email = ayon_user["attrib"]["email"]
+        ayon_users_by_name[ayon_name.lower()] = ayon_name
+        if ayon_email:
+            ayon_users_by_email[ayon_email.lower()] = ayon_name
+
+    mapped_ayon_users: Set[str] = set()
+    for ftrack_user in ftrack_users:
+        ftrack_id: str = ftrack_user["id"]
+        ftrack_name: str = ftrack_user["username"]
+        ftrack_email: str = ftrack_user["email"]
+
+        if ftrack_email and ftrack_email.lower() in ayon_users_by_email:
+            ayon_name: str = ayon_users_by_email[ftrack_email.lower()]
+            if ayon_name not in mapped_ayon_users:
+                mapping[ftrack_id] = ayon_name
+                mapped_ayon_users.add(ayon_name)
+            continue
+
+        if ftrack_name in ayon_users_by_name:
+            ayon_name: str = ayon_users_by_name[ftrack_name]
+            if ayon_name not in mapped_ayon_users:
+                mapped_ayon_users.add(ayon_name)
+                mapping[ftrack_id] = ayon_name
+
+    return mapping
+
+
+class SyncUsersFromFtrackAction(ServerAction):
+    """Sync user entities to AYON.
+
+    This action is used to synchronize users from ftrack to AYON.
+
+    When a user is created it also synchronizes the user's roles.
+    Roles are NOT synchronized on user update, because user roles might be
+    already modified in AYON.
+
+    Note: We might add interface to the action to be able to sync only specific
+    users, or to sync roles even on user update.
+
+    This action is available on project entities, but syncs all users.
+
+    Does not sync user thumbnails, might be added in the future if needed,
+    but probably only for new users or .
+    """
+
+    identifier = "sync.users.from.ftrack.to.ayon"
+    label = "AYON Admin"
+    variant = "- Sync users to AYON"
+    description = "Synchronize users based on ftrack"
+    icon = get_service_ftrack_icon_url("AYONAdmin.svg")
+
+    role_list = ["Administrator", "Project Manager"]
+    settings_key = "sync_users_from_ftrack"
+
+    def discover(self, session, entities, event):
+        """Show only on project."""
+        if (
+            len(entities) != 1
+            or entities[0].entity_type.lower() != "project"
+        ):
+            return False
+        return self.valid_roles(session, entities, event)
+
+    def launch(self, session, entities, event):
+        self.log.info("Synchronization begins")
+        fields = {
+            "id",
+            "username",
+            "is_active",
+            "email",
+            "first_name",
+            "last_name",
+            # "resource_type",
+            # "thumbnail_id",
+            # "thumbnail_url",
+        }
+        joined_fields = ", ".join(fields)
+        ftrack_users = session.query(
+            f"select {joined_fields} from User"
+        ).all()
+        ayon_users = list(ayon_api.get_users())
+        ftrack_users_by_id = {
+            ftrack_user["id"]: ftrack_user
+            for ftrack_user in ftrack_users
+        }
+        security_roles_by_id: Dict[str, "FtrackEntity"] = {
+            role["id"]: role
+            for role in session.query(
+                "select id, name, type from SecurityRole"
+            ).all()
+        }
+        ayon_role_by_user_id: Dict[str, str] = {
+            ftrack_id: "artist"
+            for ftrack_id in ftrack_users_by_id
+        }
+        user_roles_by_user_id: Dict[str, List["FtrackEntity"]] = {
+            ftrack_id: []
+            for ftrack_id in ayon_role_by_user_id
+        }
+        for security_role in session.query(
+            "select is_all_projects, is_all_open_projects"
+            ", security_role_id, user_id"
+            " from UserSecurityRole"
+        ).all():
+            role: FtrackEntity = (
+                security_roles_by_id[security_role["security_role_id"]]
+            )
+            user_id: str = security_role["user_id"]
+            user_roles_by_user_id.setdefault(user_id, []).append(role)
+            if (
+                not security_role["is_all_projects"]
+                and not security_role["is_all_open_projects"]
+            ):
+                continue
+
+            if role["name"] == "Administrator":
+                ayon_role_by_user_id[user_id] = "admin"
+                continue
+            current_role = ayon_role_by_user_id[user_id]
+            if role["name"] == "Project Manager" and current_role != "admin":
+                ayon_role_by_user_id[user_id] = "manager"
+
+        ftrack_projects: List[FtrackEntity] = session.query(
+            "select id, full_name, is_private from Project"
+        )
+        users_mapping: Dict[str, str] = map_ftrack_users_to_ayon_users(
+            ftrack_users, ayon_users
+        )
+        for ftrack_id, ayon_user_name in users_mapping.items():
+            ftrack_user = ftrack_users_by_id[ftrack_id]
+            ayon_user_data = {
+                "ftrack": {
+                    "id": ftrack_id,
+                    "username": ftrack_user["username"],
+                }
+            }
+            ayon_role = ayon_role_by_user_id[ftrack_id]
+
+            attrib = {}
+            if ftrack_user["email"]:
+                attrib["email"] = ftrack_user["email"]
+
+            full_name_items = []
+            for key in "first_name", "last_name":
+                value = ftrack_user[key]
+                if value:
+                    full_name_items.append(value)
+
+            if full_name_items:
+                attrib["full_name"] = " ".join(full_name_items)
+
+            is_admin = ayon_role == "admin"
+            is_manager = ayon_role == "manager"
+            if not ayon_user_name:
+                ayon_user_data["isAdmin"] = is_admin
+                ayon_user_data["isManger"] = is_manager
+                # Create new user
+                if not is_admin and not is_manager:
+                    # TODO define default access groups in settings???
+                    # - they can be customized
+                    # TODO use predefined endpoints (are not available
+                    #   at the moment of this PR)
+                    ayon_user_data["defaultAccessGroups"] = ["artist"]
+                    ayon_user_data["accessGroups"] = (
+                        self._calculate_default_access_groups(
+                            ftrack_projects,
+                            user_roles_by_user_id[ftrack_id]
+                        )
+                    )
+
+                new_ayon_user = {
+                    "active": ftrack_user["is_active"],
+                    "data": ayon_user_data,
+                }
+                if attrib:
+                    new_ayon_user["attrib"] = attrib
+                username = ftrack_user["username"]
+                ayon_api.put(
+                    f"users/{username}",
+                    **new_ayon_user,
+                )
+                continue
+
+            # Fetch user with REST to get 'data'
+            ayon_user = ayon_api.get_user(ayon_user_name)
+            user_diffs = {}
+            if ftrack_user["is_active"] != ayon_user["active"]:
+                user_diffs["active"] = ftrack_user["is_active"]
+
+            # Comapre 'data' field
+            current_user_data = ayon_user["data"]
+            data_diffs = {}
+            if "ftrack" in current_user_data:
+                ayon_user_ftrack_data = current_user_data["ftrack"]
+                for key, value in ayon_user_data["ftrack"].items():
+                    if (
+                        key not in ayon_user_ftrack_data
+                        or ayon_user_ftrack_data[key] != value
+                    ):
+                        ayon_user_ftrack_data.update(ayon_user_data["ftrack"])
+                        data_diffs["ftrack"] = ayon_user_ftrack_data
+                        break
+
+            if ayon_role == "admin":
+                if not current_user_data.get("isAdmin"):
+                    data_diffs["isAdmin"] = True
+                    if current_user_data.get("isManger"):
+                        data_diffs["isManger"] = False
+
+            elif ayon_role == "manager":
+                if not current_user_data.get("isManger"):
+                    data_diffs["isManger"] = True
+                    if current_user_data.get("isAdmin"):
+                        data_diffs["isAdmin"] = False
+
+            elif ayon_role == "artist":
+                if current_user_data.get("isAdmin"):
+                    data_diffs["isAdmin"] = False
+
+                if current_user_data.get("isManger"):
+                    data_diffs["isManger"] = False
+
+            if data_diffs:
+                user_diffs["data"] = data_diffs
+
+            # Compare 'attrib' fields
+            for key, value in attrib.items():
+                if ayon_user["attrib"].get(key) != value:
+                    attrib_diffs = user_diffs.setdefault("attrib", {})
+                    attrib_diffs[key] = value
+
+            if user_diffs:
+                ayon_api.put(
+                    f"users/{ayon_user_name}",
+                    **user_diffs,
+                )
+
+        self.log.info("Synchronization finished")
+        return True
+
+    def _calculate_default_access_groups(
+        self, ftrack_projects, user_roles
+    ):
+        available_project_names = []
+        project_names = set(ayon_api.get_project_names(active=None))
+        for ftrack_project in ftrack_projects:
+            project_name = ftrack_project["full_name"]
+            if project_name not in project_names:
+                continue
+
+            if not ftrack_project["is_private"]:
+                available_project_names.append(project_name)
+                continue
+
+            project_id = ftrack_project["id"]
+            for role in user_roles:
+                if role["project_id"] == project_id:
+                    available_project_names.append(project_name)
+                    break
+
+        return {
+            project_name: ["artist"]
+            for project_name in available_project_names
+        }

--- a/services/processor/processor/default_handlers/action_sync_users.py
+++ b/services/processor/processor/default_handlers/action_sync_users.py
@@ -162,7 +162,7 @@ class SyncUsersFromFtrackAction(ServerAction):
                 }
                 if attrib:
                     new_ayon_user["attrib"] = attrib
-                username = ftrack_user["username"]
+                username = ftrack_user["username"].split("@", 1)[0]
                 ayon_api.put(
                     f"users/{username}",
                     **new_ayon_user,

--- a/services/processor/processor/default_handlers/event_users_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_users_sync_from_ftrack.py
@@ -1,0 +1,157 @@
+from typing import Dict, Union
+
+import ayon_api
+
+from ftrack_common import BaseEventHandler
+from processor.lib import map_ftrack_users_to_ayon_users
+
+
+class SyncUsersFromFtrackEvent(BaseEventHandler):
+    """Sync access groups of private projects.
+
+    Listen to changes of user roles in private projects. When user is added
+    to the project, user is added to the project access group in AYON.
+    When user is removed from the project, user is removed from the project
+    access group in AYON.
+
+    That works only for artist users. Admin and manager users can access all
+    projects in AYON anyway. Roles from 'defaultAccessGroups'
+    are used as roles on user in AYON.
+    """
+    def launch(self, session, event):
+        project_ids_by_user_id = {}
+        project_ids = set()
+
+        for ent_info in event["data"].get("entities", []):
+            if ent_info.get("entityType") != "userroleproject":
+                continue
+
+            change_user_ids = [
+                p["entityId"]
+                for p in ent_info["parents"]
+                if p["entityType"] == "user"
+            ]
+            if not change_user_ids:
+                continue
+
+            project_id_change = ent_info["changes"].get("project_id")
+            if not project_id_change:
+                continue
+
+            project_id = project_id_change["new"] or project_id_change["old"]
+            if not project_id:
+                continue
+
+            user_id = change_user_ids[0]
+            project_ids.add(project_id)
+            filtered_changes = project_ids_by_user_id.setdefault(
+                user_id, {}
+            )
+            filtered_changes[project_id] = project_id_change["new"] is None
+
+        if not project_ids_by_user_id:
+            return
+
+        joined_project_ids = self.join_query_keys(project_ids)
+        projects = session.query(
+            "select id, full_name, is_private from Project"
+            f" where id in ({joined_project_ids})"
+        ).all()
+        # Filter only private projects
+        # - maybe it could be done in query?
+        project_ids_by_name = {
+            project["full_name"]: project["id"]
+            for project in projects
+            if project["is_private"]
+        }
+        if not project_ids_by_name:
+            return
+
+        # Filter only projects that are available in AYON
+        ayon_projects_names = {
+            ayon_project["name"]
+            for ayon_project in ayon_api.get_projects(
+                set(project_ids_by_name), fields={"name"}
+            )
+        }
+        filtered_project_ids = {
+            project_ids_by_name[project_name]
+            for project_name in ayon_projects_names
+            if project_name in project_ids_by_name
+        }
+        if not filtered_project_ids:
+            return
+
+        # Filter only artist users
+        # - admin and manager users can access all projects in AYON
+        ayon_users = [
+            user
+            for user in ayon_api.get_users()
+            if not user["isAdmin"] and not user["isManager"]
+        ]
+        if not ayon_users:
+            return
+
+        joined_user_ids = self.join_query_keys(project_ids_by_user_id)
+        ftrack_users = session.query(
+            "select id, username, email from User"
+            f" where id in ({joined_user_ids})"
+        ).all()
+        users_mapping: Dict[str, Union[str, None]] = (
+            map_ftrack_users_to_ayon_users(ftrack_users, ayon_users)
+        )
+        project_name_by_id = {
+            project_id: project_name
+            for project_name, project_id in project_ids_by_name.items()
+        }
+        for ftrack_id, ayon_username in users_mapping.items():
+            # Mapping was not found - ignore
+            if not ayon_username:
+                continue
+
+            removed_by_project_id = project_ids_by_user_id[ftrack_id]
+            filtered_project_ids = {
+                project_id
+                for project_id in removed_by_project_id
+                if project_id in filtered_project_ids
+            }
+            if not filtered_project_ids:
+                continue
+
+            ayon_user = ayon_api.get_user(ayon_username)
+            user_data = ayon_user["data"]
+            default_user_access_groups = user_data.get(
+                "defaultAccessGroups", []
+            )
+            user_access_groups = user_data.setdefault("accessGroups", {})
+
+            changed = False
+            for project_id in filtered_project_ids:
+                if project_id not in removed_by_project_id:
+                    continue
+
+                removed: bool = removed_by_project_id[project_id]
+                project_name = project_name_by_id[project_id]
+                if removed and project_name not in user_access_groups:
+                    continue
+
+                access_groups = user_access_groups.setdefault(
+                    project_name, []
+                )
+                if removed:
+                    if access_groups:
+                        access_groups.clear()
+                        changed = True
+
+                elif not access_groups:
+                    for group in default_user_access_groups:
+                        if group not in access_groups:
+                            access_groups.append(group)
+                            changed = True
+
+            if changed:
+                ayon_api.patch(
+                    f"users/{ayon_username}",
+                    data=user_data
+                )
+                self.log.info(f"Updated access groups of '{ayon_username}'.")

--- a/services/processor/processor/default_handlers/event_users_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_users_sync_from_ftrack.py
@@ -87,7 +87,11 @@ class SyncUsersFromFtrackEvent(BaseEventHandler):
         ayon_users = [
             user
             for user in ayon_api.get_users()
-            if not user["isAdmin"] and not user["isManager"]
+            if (
+                not user["isAdmin"]
+                and not user["isManager"]
+                and not user["isService"]
+            )
         ]
         if not ayon_users:
             return

--- a/services/processor/processor/lib/__init__.py
+++ b/services/processor/processor/lib/__init__.py
@@ -1,8 +1,13 @@
+from .users import (
+    map_ftrack_users_to_ayon_users,
+)
 from .sync_from_ftrack import (
     SyncFromFtrack,
 )
 
 
 __all__ = (
+    "map_ftrack_users_to_ayon_users",
+
     "SyncFromFtrack",
 )

--- a/services/processor/processor/lib/users.py
+++ b/services/processor/processor/lib/users.py
@@ -1,0 +1,57 @@
+from typing import Dict, List, Set, Union, Any
+
+import ftrack_api.entity.user
+
+
+def map_ftrack_users_to_ayon_users(
+    ftrack_users: List[ftrack_api.entity.user.User],
+    ayon_users: List[Dict[str, Any]],
+) -> Dict[str, Union[str, None]]:
+    """Map ftrack users to AYON users.
+
+    Mapping is based on 2 possible keys, email and username where email has
+    higher priority. Once AYON user is mapped it cannot be mapped again to
+    different user.
+
+    Args:
+        ftrack_users (List[ftrack_api.entity.user.User]): List of ftrack users.
+        ayon_users (List[Dict[str, Any]]): List of AYON users.
+
+    Returns:
+        Dict[str, Union[str, None]]: Mapping of ftrack user id
+            to AYON username.
+
+    """
+    mapping: Dict[str, Union[str, None]] = {
+        user["id"]: None
+        for user in ftrack_users
+    }
+    ayon_users_by_email: Dict[str, str] = {}
+    ayon_users_by_name: Dict[str, str] = {}
+    for ayon_user in ayon_users:
+        ayon_name = ayon_user["name"]
+        ayon_email = ayon_user["attrib"]["email"]
+        ayon_users_by_name[ayon_name.lower()] = ayon_name
+        if ayon_email:
+            ayon_users_by_email[ayon_email.lower()] = ayon_name
+
+    mapped_ayon_users: Set[str] = set()
+    for ftrack_user in ftrack_users:
+        ftrack_id: str = ftrack_user["id"]
+        ftrack_name: str = ftrack_user["username"]
+        ftrack_email: str = ftrack_user["email"]
+
+        if ftrack_email and ftrack_email.lower() in ayon_users_by_email:
+            ayon_name: str = ayon_users_by_email[ftrack_email.lower()]
+            if ayon_name not in mapped_ayon_users:
+                mapping[ftrack_id] = ayon_name
+                mapped_ayon_users.add(ayon_name)
+            continue
+
+        if ftrack_name in ayon_users_by_name:
+            ayon_name: str = ayon_users_by_name[ftrack_name]
+            if ayon_name not in mapped_ayon_users:
+                mapped_ayon_users.add(ayon_name)
+                mapping[ftrack_id] = ayon_name
+
+    return mapping

--- a/services/processor/processor/lib/users.py
+++ b/services/processor/processor/lib/users.py
@@ -38,7 +38,8 @@ def map_ftrack_users_to_ayon_users(
     mapped_ayon_users: Set[str] = set()
     for ftrack_user in ftrack_users:
         ftrack_id: str = ftrack_user["id"]
-        ftrack_name: str = ftrack_user["username"]
+        # Make sure username does not contain '@' character
+        ftrack_name: str = ftrack_user["username"].split("@", 1)[0]
         ftrack_email: str = ftrack_user["email"]
 
         if ftrack_email and ftrack_email.lower() in ayon_users_by_email:


### PR DESCRIPTION
## Changelog Description
Added option to synchronize users and user roles from ftrack to AYON.

## Additional info
Users are synchronized based on email or username (email is used first class citizen). Admin is synchronized as admin, manager is synchronized as manager and any other user is synchronized as artist. Active states are synchronized too. Changes of private project are propagated to AYON access groups.

## Testing notes:
### Users sync
1. Start both services.
2. Run admin action `Sync users to AYON` on project.
3. Choose default access groups for new artists.
4. That should sync users from ftrack to AYON.

### Private project roles
1. Create private project.
2. Run prepare project action.
3. The project in AYON should be available only for admins and managers.
5. In ftrack add permission to the project for some artist user.
6. The user in AYON should have permissions to see the project.