### PR TITLE
Event handlers: Add cleanup method

### DIFF
--- a/client/ayon_ftrack/common/event_handlers/ftrack_base_handler.py
+++ b/client/ayon_ftrack/common/event_handlers/ftrack_base_handler.py
@@ -122,6 +122,13 @@ class BaseHandler(metaclass=ABCMeta):
         """Subscribe to event topics."""
         pass
 
+    def cleanup(self):
+        """Cleanup handler.
+
+        This method should end threads, timers, close connections, etc.
+        """
+        pass
+
     def register_wrapper(self, func):
         @functools.wraps(func)
         def wrapper_register(*args, **kwargs):

--- a/client/ayon_ftrack/common/ftrack_server.py
+++ b/client/ayon_ftrack/common/ftrack_server.py
@@ -115,6 +115,13 @@ class FtrackServer:
         try:
             session.event_hub.wait()
         finally:
+            for handler in self._cached_objects:
+                try:
+                    handler.cleanup()
+                except Exception:
+                    self.log.warning(
+                        "Failed to cleanup handler", exc_info=True
+                    )
             self._is_running = False
             self._cached_modules = []
 

--- a/services/processor/processor/handlers_to_convert/action_create_review_session.py
+++ b/services/processor/processor/handlers_to_convert/action_create_review_session.py
@@ -47,7 +47,6 @@ class CreateDailyReviewSessionServerAction(ServerAction):
         )
 
         self._cycle_timers_by_id = {}
-        self._last_cyle_time = None
         self._day_delta = datetime.timedelta(days=1)
 
     def discover(self, session, entities, event):
@@ -106,12 +105,10 @@ class CreateDailyReviewSessionServerAction(ServerAction):
         expected_next_trigger = datetime.datetime(
             now.year, now.month, now.day, h, m, s
         )
-        if expected_next_trigger > now:
-            seconds = (expected_next_trigger - now).total_seconds()
-        else:
+        if expected_next_trigger <= now:
             expected_next_trigger += self._day_delta
-            seconds = (expected_next_trigger - now).total_seconds()
-        return seconds, expected_next_trigger
+
+        return (expected_next_trigger - now).total_seconds()
 
     def register(self, *args, **kwargs):
         """Override register to be able trigger """
@@ -129,11 +126,7 @@ class CreateDailyReviewSessionServerAction(ServerAction):
                 timer.cancel()
 
     def _add_timer_callback(self):
-        seconds_delta, cycle_time = self._calculate_next_cycle_delta()
-
-        # Store cycle time which will be used to create next timer
-        # Create timer thread
-        self._last_cyle_time = cycle_time
+        seconds_delta = self._calculate_next_cycle_delta()
 
         timer_id = uuid.uuid4().hex
         cycle_timer = threading.Timer(

--- a/services/processor/processor/handlers_to_convert/action_create_review_session.py
+++ b/services/processor/processor/handlers_to_convert/action_create_review_session.py
@@ -2,6 +2,7 @@ import threading
 import datetime
 import copy
 import collections
+import uuid
 
 import ftrack_api
 
@@ -45,7 +46,7 @@ class CreateDailyReviewSessionServerAction(ServerAction):
             *args, **kwargs
         )
 
-        self._cycle_timer = None
+        self._cycle_timers_by_id = {}
         self._last_cyle_time = None
         self._day_delta = datetime.timedelta(days=1)
 
@@ -115,38 +116,43 @@ class CreateDailyReviewSessionServerAction(ServerAction):
     def register(self, *args, **kwargs):
         """Override register to be able trigger """
         # Register server action as would be normally
-        super(CreateDailyReviewSessionServerAction, self).register(
-            *args, **kwargs
-        )
+        super().register(*args, **kwargs)
 
-        seconds_delta, cycle_time = self._calculate_next_cycle_delta()
-
-        # Store cycle time which will be used to create next timer
-        self._last_cyle_time = cycle_time
-        # Create timer thread
-        self._cycle_timer = threading.Timer(
-            seconds_delta, self._timer_callback
-        )
-        self._cycle_timer.start()
+        self._add_timer_callback()
 
         self._check_review_session()
 
-    def _timer_callback(self):
-        # Stop chrono callback if session is closed
+    def cleanup(self):
+        for timer_id in list(self._cycle_timers_by_id.keys()):
+            timer = self._cycle_timers_by_id.pop(timer_id, None)
+            if timer is not None:
+                timer.cancel()
+
+    def _add_timer_callback(self):
+        seconds_delta, cycle_time = self._calculate_next_cycle_delta()
+
+        # Store cycle time which will be used to create next timer
+        # Create timer thread
+        self._last_cyle_time = cycle_time
+
+        timer_id = uuid.uuid4().hex
+        cycle_timer = threading.Timer(
+            seconds_delta, self._timer_callback, [timer_id]
+        )
+        self._cycle_timers_by_id[timer_id] = cycle_timer
+        cycle_timer.start()
+
+    def _timer_callback(self, timer_id):
+        timer = self._cycle_timers_by_id.pop(timer_id, None)
+        if timer is None:
+            return
+
+        # Stop chrono callbacks if session is closed
         if self.session.closed:
             return
 
-        if (
-            self._cycle_timer is not None
-            and self._last_cyle_time is not None
-        ):
-            seconds_delta, cycle_time = self._calculate_next_cycle_delta()
-            self._last_cyle_time = cycle_time
+        self._add_timer_callback()
 
-            self._cycle_timer = threading.Timer(
-                seconds_delta, self._timer_callback
-            )
-            self._cycle_timer.start()
         self._check_review_session()
 
     def _check_review_session(self):

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -183,9 +183,14 @@ def _cleanup_process():
     """Cleanup timer threads on exit."""
     logging.info("Process stop requested. Terminating process.")
     logging.info("Canceling threading timers.")
+    counter = 0
     for thread in threading.enumerate():
         if isinstance(thread, threading.Timer):
             thread.cancel()
+            counter += 1
+
+    if counter:
+        logging.info(f"Canceled {counter} timers.")
 
     logging.info("Stopping main loop.")
     if not _GlobalContext.stop_event.is_set():

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -25,6 +25,7 @@ class _GlobalContext:
     stop_event = threading.Event()
     session = None
     session_fail_logged = 0
+    process_cleaned_up = False
 
 
 def get_handler_paths() -> list[str]:
@@ -181,6 +182,9 @@ def main_loop():
 
 def _cleanup_process():
     """Cleanup timer threads on exit."""
+    if _GlobalContext.process_cleaned_up:
+        return
+    _GlobalContext.process_cleaned_up = True
     logging.info("Process stop requested. Terminating process.")
     logging.info("Canceling threading timers.")
     counter = 0


### PR DESCRIPTION
## Changelog Description
Event handlers have `cleanup` method which is called when ftrack server stops.

## Additional info
This works only for event handlers that were not discovered with `register` function in the file. This way we can call "cleanup" code related to handlers, for example threading timers.

## Testing notes:
Only way how to test it is to have running service for few days and validate that Create daily lists is executed only once each day.
