### PR TITLE
Service tools: Fake 'ftrack_common.event_handlers'

### DIFF
--- a/service_tools/main.py
+++ b/service_tools/main.py
@@ -85,7 +85,9 @@ def main():
 
     # Fix 'ftrack_common' import
     import common
+    import common.event_handlers
     sys.modules["ftrack_common"] = common
+    sys.modules["ftrack_common.event_handlers"] = common.event_handlers
 
     if service_name == "processor":
         from processor import main as service_main


### PR DESCRIPTION
## Changelog Description
Fake submodule so class imported from it is considered as the same classes.

## Additional review information
This is for cases when any base handle class is not imported from `ftrack_common` but from `ftrack_common.event_handlers`. In that case (if module is not in `sys.modules` yet), it will reimport the files again, which will cause different ids of classes. Preparing it for python will avoid importing it again.

## Testing notes:
1. When using service tools, it is possible to dicover action that imports base class from `ftrack_common.event_handlers`.
