### PR TITLE
To AYON Sync: Sync task assignees

### DIFF
--- a/services/processor/processor/lib/users.py
+++ b/services/processor/processor/lib/users.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Union, Any
+from typing import Dict, List, Set, Union, Any, Optional
 
 import ayon_api
 import ftrack_api.entity.user
@@ -6,7 +6,7 @@ import ftrack_api.entity.user
 
 def map_ftrack_users_to_ayon_users(
     ftrack_users: List[ftrack_api.entity.user.User],
-    ayon_users: List[Dict[str, Any]] = None,
+    ayon_users: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Union[str, None]]:
     """Map ftrack users to AYON users.
 

--- a/services/processor/processor/lib/users.py
+++ b/services/processor/processor/lib/users.py
@@ -1,11 +1,12 @@
 from typing import Dict, List, Set, Union, Any
 
+import ayon_api
 import ftrack_api.entity.user
 
 
 def map_ftrack_users_to_ayon_users(
     ftrack_users: List[ftrack_api.entity.user.User],
-    ayon_users: List[Dict[str, Any]],
+    ayon_users: List[Dict[str, Any]] = None,
 ) -> Dict[str, Union[str, None]]:
     """Map ftrack users to AYON users.
 
@@ -22,6 +23,9 @@ def map_ftrack_users_to_ayon_users(
             to AYON username.
 
     """
+    if ayon_users is None:
+        ayon_users = ayon_api.get_users()
+
     mapping: Dict[str, Union[str, None]] = {
         user["id"]: None
         for user in ftrack_users


### PR DESCRIPTION
## Changelog Description
Sync ftrack to AYON can sync task assignees.

## Additional review information
If users are synchronized it does allow to sync users from ftrack to AYON. During action are synchronized assignees from ftrack as are. If AYON user assigned on task cannot be mapped to ftrack user it is kept in AYON. Event processing just removed/adds assignee based on information from event.

## Testing notes:
### Preparation
_Only step 2 is required when using service tools._
1. If you're going to test PR using docker images, you have to first change version in `package.py` to e.g. `1.2.2-dev`.
2. Create addon package, upload it to server and use in bundle (+ copy settings).
3. Build docker leecher and process images.
4. Create services in AYON server.
5. Run ASH.

### Functionality testing
1. Make sure to run `AYON Admin - Sync users to AYON` first, so you have actually users to map.
2. Enabled auto sync on a project.
3. That should already sync assignees to AYON.
4. Change assignee on a task in ftrack.
6. The change should be propagated to AYON.