### PR TITLE
AYON to ftrack sync: Sync assignments on task

### DIFF
--- a/client/ayon_ftrack/common/__init__.py
+++ b/client/ayon_ftrack/common/__init__.py
@@ -38,6 +38,8 @@ __all__ = (
     "get_ftrack_icon_url",
     "get_service_ftrack_icon_url",
 
+    "map_ftrack_users_to_ayon_users",
+
     "get_ayon_attr_configs",
     "query_custom_attribute_values",
     "get_custom_attributes_by_entity_id",
@@ -96,6 +98,8 @@ from .lib import (
     get_ftrack_icon_url,
     get_service_ftrack_icon_url,
 )
+
+from .users import map_ftrack_users_to_ayon_users
 
 from .custom_attributes import (
     get_ayon_attr_configs,

--- a/client/ayon_ftrack/common/users.py
+++ b/client/ayon_ftrack/common/users.py
@@ -18,6 +18,8 @@ def map_ftrack_users_to_ayon_users(
     higher priority. Once AYON user is mapped it cannot be mapped again to
     different user.
 
+    Fields used from ftrack users: 'id', 'username', 'email'.
+
     Args:
         ftrack_users (List[ftrack_api.entity.user.User]): List of ftrack users.
         ayon_users (List[Dict[str, Any]]): List of AYON users.

--- a/client/ayon_ftrack/common/users.py
+++ b/client/ayon_ftrack/common/users.py
@@ -1,13 +1,17 @@
-from typing import Dict, List, Set, Union, Any, Optional
+import typing
+from typing import Dict, List, Set, Any, Optional
 
 import ayon_api
-import ftrack_api.entity.user
+
+if typing.TYPE_CHECKING:
+    from typing import Union
+    import ftrack_api.entity.user
 
 
 def map_ftrack_users_to_ayon_users(
-    ftrack_users: List[ftrack_api.entity.user.User],
+    ftrack_users: List["ftrack_api.entity.user.User"],
     ayon_users: Optional[List[Dict[str, Any]]] = None,
-) -> Dict[str, Union[str, None]]:
+) -> Dict[str, "Union[str, None]"]:
     """Map ftrack users to AYON users.
 
     Mapping is based on 2 possible keys, email and username where email has
@@ -26,7 +30,7 @@ def map_ftrack_users_to_ayon_users(
     if ayon_users is None:
         ayon_users = ayon_api.get_users()
 
-    mapping: Dict[str, Union[str, None]] = {
+    mapping: Dict[str, "Union[str, None]"] = {
         user["id"]: None
         for user in ftrack_users
     }

--- a/services/ayontof/ayontof/logic.py
+++ b/services/ayontof/ayontof/logic.py
@@ -4,6 +4,11 @@ from typing import Optional, Dict, Any
 import ftrack_api
 import ayon_api
 
+from ftrack_common import (
+    FTRACK_ID_ATTRIB,
+    map_ftrack_users_to_ayon_users,
+)
+
 from .structures import JobEventType
 
 
@@ -36,18 +41,36 @@ class EventProcessor:
                 status=job_status
             )
 
+    def _get_entity_by_id(self, project_name, entity_type, entity_id):
+        if entity_type == "project":
+            return ayon_api.get_project(project_name)
+        if entity_type == "folder":
+            return ayon_api.get_folder_by_id(project_name, entity_id)
+        if entity_type == "task":
+            return ayon_api.get_task_by_id(project_name, entity_id)
+        if entity_type == "product":
+            return ayon_api.get_product_by_id(project_name, entity_id)
+        if entity_type == "version":
+            return ayon_api.get_version_by_id(project_name, entity_id)
+        self._log.warning(f"Unsupported entity type: {entity_type}")
+        return None
+
     def _process_reviewable_created(self, source_event: Dict[str, Any]):
         # TODO implement
         pass
 
     def _process_entity_event(self, source_event: Dict[str, Any]):
-        converted_data = self._convert_entity_event(source_event)
-        if converted_data is None:
+        entity_data = self._convert_entity_event(source_event)
+        if entity_data is None:
             return
+
+        if entity_data["action"] == "update":
+            self._handle_update_event(entity_data)
 
     def _convert_entity_event(
         self, source_event: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
+        # TODO find out if this conversion makes sense?
         topic: str = source_event["topic"]
         topic_parts = topic.split(".")
         if len(topic_parts) != 3:
@@ -120,3 +143,125 @@ class EventProcessor:
             return output
 
         return None
+
+    def _handle_update_event(self, changes_data):
+        entity_type = changes_data["entity_type"]
+        # TODO implement all entities
+        if entity_type in ("project", "folder", "product", "version"):
+            return
+
+        project_name = changes_data["project_name"]
+        entity_id = changes_data["entity_id"]
+        entity = self._get_entity_by_id(project_name, entity_type, entity_id)
+        if entity is None:
+            self._log.warning(
+                f"Entity with id '{entity_id}'"
+                f" not found in Project '{project_name}'"
+            )
+            return
+
+        # TODO implement more logic
+        if (
+            entity_type == "task"
+            and changes_data["update_key"] == "assignees"
+        ):
+            self._handle_task_assignees_change(entity, changes_data)
+            return
+        self._log.debug("Unhandled entity update event")
+
+    def _handle_task_assignees_change(self, entity, changes_data):
+        self._log.info("Handling assignees changes.")
+        # Find ftrack task entity
+        task_ftrack_id = entity["attrib"].get(FTRACK_ID_ATTRIB)
+        # QUESTION try to find entity by path?
+        if not task_ftrack_id:
+            self._log.info("Task is not linked to ftrack.")
+            return
+
+        ft_entity = self._session.query(
+            f"Task where id is '{task_ftrack_id}'"
+        ).first()
+        if ft_entity is None:
+            self._log.info(
+                f"ftack entity with id '{task_ftrack_id}' was not found."
+            )
+            return
+
+        changes = changes_data["changes"]
+        # Split added and removed assignees
+        added_assignees = (
+            set(changes["new"]["assignees"])
+            - set(changes["old"]["assignees"])
+        )
+        removed_assignees = (
+            set(changes["old"]["assignees"])
+            - set(changes["new"]["assignees"])
+        )
+
+        ft_users = self._session.query(
+            "select id, username, email from User"
+        ).all()
+        ayon_username_by_ft_id = map_ftrack_users_to_ayon_users(ft_users)
+        ft_id_by_ay_username = {
+            ayon_username: ft_user_id
+            for ft_user_id, ayon_username in ayon_username_by_ft_id.items()
+            if ayon_username
+        }
+        # Skip if there is no valid user mapping for changed assignees
+        changed_assignees = added_assignees | removed_assignees
+        if not set(ft_id_by_ay_username) & changed_assignees:
+            self._log.info(
+                "Changed assignees in AYON don't have"
+                " valid mapping to ftrack users."
+            )
+            return
+
+        appointments = self._session.query(
+            "select resource_id, context_id from Appointment"
+            f" where context_id is '{task_ftrack_id}'"
+            " and type is 'assignment'"
+        ).all()
+        appointments_by_user_ids = {
+            appointment["resource_id"]: appointment
+            for appointment in appointments
+        }
+        for ayon_username in added_assignees:
+            ftrack_id = ft_id_by_ay_username.get(ayon_username)
+            if not ftrack_id:
+                continue
+
+            if ftrack_id in appointments_by_user_ids:
+                self._log.info(
+                    f"AYON user '{ayon_username}'"
+                    f" is already assigned in ftrack."
+                )
+                continue
+
+            self._session.create(
+                "Appointment",
+                {
+                    "resource_id": ftrack_id,
+                    "context_id": task_ftrack_id,
+                    "type": "assignment",
+                }
+            )
+            self._log.info(
+                f"Creating assignment of user '{ayon_username}' in ftrack."
+            )
+
+        for ayon_username in removed_assignees:
+            ftrack_id = ft_id_by_ay_username.get(ayon_username)
+            if not ftrack_id:
+                continue
+            if ftrack_id not in appointments_by_user_ids:
+                self._log.info(
+                    f"AYON user '{ayon_username}' is not assigned in ftrack."
+                )
+                continue
+            self._session.delete(appointments_by_user_ids[ftrack_id])
+            self._log.info(
+                f"Removing assignment of user '{ayon_username}' in ftrack."
+            )
+
+        if self._session.recorded_operations:
+            self._session.commit()

--- a/services/processor/processor/default_handlers/action_prepare_project.py
+++ b/services/processor/processor/default_handlers/action_prepare_project.py
@@ -14,8 +14,10 @@ from ftrack_common import (
     get_service_ftrack_icon_url,
     get_ayon_attr_configs,
     query_custom_attribute_values,
+    map_ftrack_users_to_ayon_users,
 )
-from processor.lib import SyncFromFtrack, map_ftrack_users_to_ayon_users
+
+from processor.lib import SyncFromFtrack
 
 
 class PrepareProjectServer(ServerAction):

--- a/services/processor/processor/default_handlers/action_sync_users.py
+++ b/services/processor/processor/default_handlers/action_sync_users.py
@@ -7,8 +7,8 @@ from ftrack_common import (
     ServerAction,
     get_service_ftrack_icon_url,
     create_chunks,
+    map_ftrack_users_to_ayon_users,
 )
-from processor.lib import map_ftrack_users_to_ayon_users
 
 if typing.TYPE_CHECKING:
     from ftrack_api.entity.base import Entity as FtrackEntity

--- a/services/processor/processor/default_handlers/event_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_sync_from_ftrack.py
@@ -38,8 +38,8 @@ from ftrack_common import (
 
     create_chunks,
     join_filter_values,
+    map_ftrack_users_to_ayon_users,
 )
-from processor.lib import map_ftrack_users_to_ayon_users
 
 UNKNOWN_VALUE = object()
 

--- a/services/processor/processor/default_handlers/event_users_sync_from_ftrack.py
+++ b/services/processor/processor/default_handlers/event_users_sync_from_ftrack.py
@@ -2,8 +2,10 @@ from typing import Dict, Union
 
 import ayon_api
 
-from ftrack_common import BaseEventHandler
-from processor.lib import map_ftrack_users_to_ayon_users
+from ftrack_common import (
+    BaseEventHandler,
+    map_ftrack_users_to_ayon_users,
+)
 
 
 class SyncUsersFromFtrackEvent(BaseEventHandler):

--- a/services/processor/processor/lib/__init__.py
+++ b/services/processor/processor/lib/__init__.py
@@ -1,13 +1,8 @@
-from .users import (
-    map_ftrack_users_to_ayon_users,
-)
 from .sync_from_ftrack import (
     SyncFromFtrack,
 )
 
 
 __all__ = (
-    "map_ftrack_users_to_ayon_users",
-
     "SyncFromFtrack",
 )

--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -23,9 +23,8 @@ from ftrack_common import (
     create_chunks,
     get_custom_attributes_by_entity_id,
     get_ayon_attr_configs,
+    map_ftrack_users_to_ayon_users,
 )
-
-from .users import map_ftrack_users_to_ayon_users
 
 
 def _get_ftrack_project(session, project_name):


### PR DESCRIPTION
## Changelog Description
Simple logic to sync assignees on task from AYON to ftrack.

## Testing notes:
1. Run `ayontof` service.
2. Make sure users on AYON server and ftrack are synchronized.
3. Change assignees on AYON.
4. The changes should be propagated to ftrack.

Resolves https://github.com/ynput/ayon-ftrack/issues/161