### PR TITLE
Chore: Use platformdirs over appdirs

### DIFF
--- a/service_tools/requirements.txt
+++ b/service_tools/requirements.txt
@@ -8,6 +8,7 @@ ftrack-python-api==2.3.3
 future==0.18.2
 idna==3.4
 ayon-python-api==1.0.10
+platformdirs==4.3.6
 pydantic==1.10.2
 pyparsing==2.4.7
 python-dateutil==2.8.2

--- a/services/processor/processor/download_utils.py
+++ b/services/processor/processor/download_utils.py
@@ -9,7 +9,7 @@ import json
 import tarfile
 import zipfile
 
-import appdirs
+import platformdirs
 import ayon_api
 
 IMPLEMENTED_ARCHIVE_FORMATS = {
@@ -25,7 +25,7 @@ def get_download_root():
     root = os.getenv("AYON_FTRACK_DOWNLOAD_ROOT")
     if not root:
         root = os.path.join(
-            appdirs.user_data_dir("ayon-ftrack", "Ynput"),
+            platformdirs.user_data_dir("ayon-ftrack", "Ynput"),
             "downloads"
         )
     return root
@@ -65,8 +65,8 @@ def extract_archive_file(archive_file, dst_folder=None):
         archive_file (str): Path to a archive file.
         dst_folder (Optional[str]): Directory where content will be extracted.
             By default, same folder where archive file is.
-    """
 
+    """
     if not dst_folder:
         dst_folder = os.path.dirname(archive_file)
 

--- a/services/processor/processor/download_utils.py
+++ b/services/processor/processor/download_utils.py
@@ -70,6 +70,8 @@ def extract_archive_file(archive_file, dst_folder=None):
     if not dst_folder:
         dst_folder = os.path.dirname(archive_file)
 
+    os.makedirs(dst_folder, exist_ok=True)
+
     archive_ext, archive_type = get_archive_ext_and_type(archive_file)
 
     print(f"Extracting {archive_file} -> {dst_folder}")

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Ynput s.r.o. <info@ynput.io>"]
 python = ">=3.9,<3.10"
 ayon-python-api = "1.0.10"
 ftrack-python-api = "2.3.3"
+platformdirs = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
## Changelog Description
Replace appdirs module usage with platformdirs.

## Additional review information
Appdirs are officially unmaintained project and platformdirs is official successor.

## Testing notes:
1. Everything should work as before when there is other addon that has event handlers for processor service.
