### PR TITLE
AYON to ftrack sync: Sync attribute changes

### DIFF
--- a/services/transmitter/transmitter/logic.py
+++ b/services/transmitter/transmitter/logic.py
@@ -137,18 +137,25 @@ class EventProcessor:
             self._log.warning(f"Unexpected topic: {topic}")
             return None
 
+        project_name = source_event["project"]
+        entity_id = None
+        if entity_type == "project":
+            entity_id = project_name
         update_key = changes = entity_data = None
         if change_type == "created":
             action = "created"
-            entity_id = source_event["summary"]["entityId"]
+            if entity_id is None:
+                entity_id = source_event["summary"]["entityId"]
 
         elif change_type == "deleted":
             action = "deleted"
             entity_data = source_event["payload"]["entityData"]
-            entity_id = entity_data["id"]
+            if entity_id is None:
+                entity_id = entity_data["id"]
         else:
             action = "updated"
-            entity_id = source_event["summary"]["entityId"]
+            if entity_id is None:
+                entity_id = source_event["summary"]["entityId"]
             update_key, changes = self._prepare_update_data(
                 source_event, change_type, entity_type
             )
@@ -157,7 +164,7 @@ class EventProcessor:
 
         return EntityEventData(
             action=action,
-            project_name=source_event["project"],
+            project_name=project_name,
             entity_type=entity_type,
             entity_id=entity_id,
             entity_data=entity_data,

--- a/services/transmitter/transmitter/logic.py
+++ b/services/transmitter/transmitter/logic.py
@@ -707,6 +707,8 @@ class EventProcessor:
                     # NOTE Hack, non-hierarchical attributes will be set
                     #   to current value on entity if new value is 'None'
                     new_value = ayon_entity["attrib"][key]
+
+                # Value is already same (or both are unset)
                 if new_value == old_value:
                     continue
 

--- a/services/transmitter/transmitter/service.py
+++ b/services/transmitter/transmitter/service.py
@@ -26,6 +26,7 @@ def _prepare_source_topics():
         ("entity.{}.created", all_types),
         ("entity.{}.deleted", all_types),
         ("entity.{}.active_changed", all_types),
+        ("entity.{}.attrib_changed", all_types),
         ("entity.{}.data_changed", all_types),
         ("entity.{}.type_changed", {"folder", "task", "product"}),
         ("entity.{}.thumbnail_changed", {"folder", "task", "version"}),


### PR DESCRIPTION
## Changelog Description
Changes of attributes in AYON are propagated to ftrack.

## Additional review information
Current implementation expects that attribute name matches custom attribute in ftrack. The value is not validated, so if types are not matching, or are invalid it will most probably fail (future enhancement).

### TODOs
- [x] Sync attributes that are not custom attributes in ftrack.

## Testing notes:
1. Start transmitter service.
2. Change attributes in AYON.
3. All changed values should be propagated to ftrack.

Resolves https://github.com/ynput/ayon-ftrack/issues/162