### PR TITLE
Processor: Fail stuck process events

### DIFF
--- a/services/processor/processor/ftrack_session.py
+++ b/services/processor/processor/ftrack_session.py
@@ -20,7 +20,7 @@ import ftrack_api.event
 from weakref import WeakMethod
 
 from ayon_api import (
-    get_service_addon_name,
+    get_service_name,
     enroll_event_job,
     get_event,
     get_events,
@@ -40,7 +40,7 @@ class ProcessEventHub(ftrack_api.event.hub.EventHub):
         return enroll_event_job(
             source_topic="ftrack.leech",
             target_topic="ftrack.proc",
-            sender=get_service_addon_name(),
+            sender=get_service_name(),
             description="Event processing",
             sequential=True,
         )
@@ -55,7 +55,7 @@ class ProcessEventHub(ftrack_api.event.hub.EventHub):
 
         update_event(
             event_id,
-            sender=get_service_addon_name(),
+            sender=get_service_name(),
             status="finished",
             description=description,
         )


### PR DESCRIPTION
## Changelog Description
Processor service marks events stuck for 10 minutes as failed.

## Additional review information
Avoid having stuck enrolled process jobs without option to "auto-fix". It is reasonable to say that event processing that takes more than 10 minutes should be processed other way than standard listener service. This auto-fix allows to use correct service name in enroll event function.

## Testing notes:
1. To find out if it works, one must have "stuck", with `"pending"` status, event with `ftrack.process` topic in events database.
2. If that happens then after 10 minutes is marked as failed so other processor services can continue.
