### PR TITLE
Fill environment variables for farm jobs

### DIFF
--- a/client/ayon_ftrack/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_ftrack/plugins/publish/collect_farm_env_variables.py
@@ -1,0 +1,30 @@
+import os
+
+import pyblish.api
+
+try:
+    from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+except ImportError:
+    # NOTE Can be removed when ayon-core >= 1.0.10 is required in package.py
+    FARM_JOB_ENV_DATA_KEY = "farmJobEnv"
+
+
+class CollectFtrackJobEnvVars(pyblish.api.ContextPlugin):
+    """Collect set of environment variables to submit with deadline jobs"""
+    order = pyblish.api.CollectorOrder - 0.45
+    label = "Collect ftrack farm environment variables"
+    targets = ["local"]
+
+    def process(self, context):
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+
+        # Disable colored logs on farm
+        for key in [
+            "FTRACK_SERVER",
+            "FTRACK_API_USER",
+            "FTRACK_API_KEY",
+        ]:
+            value = os.getenv(key)
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value

--- a/client/ayon_ftrack/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_ftrack/plugins/publish/collect_farm_env_variables.py
@@ -17,8 +17,6 @@ class CollectFtrackJobEnvVars(pyblish.api.ContextPlugin):
 
     def process(self, context):
         env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
-
-        # Disable colored logs on farm
         for key in [
             "FTRACK_SERVER",
             "FTRACK_API_USER",


### PR DESCRIPTION
## Changelog Description
Fill environment variables for farm in publish plugins.

## Additional review information
Move control to collect ftrack environment variables, needed for farm jobs, to ftrack addon.

## Testing notes:
1. At this moment probably nothing changed because deadline has to start using the key.

Resolves https://github.com/ynput/ayon-ftrack/issues/179