### PR TITLE
Chore: Fix transmitter service manage script

### DIFF
--- a/services/transmitter/Dockerfile
+++ b/services/transmitter/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
 
 RUN mkdir /service
 COPY ./transmitter /service/transmitter
+COPY ./ftrack_common /service/ftrack_common
 COPY ./pyproject.toml /service/pyproject.toml
 WORKDIR /service
 

--- a/services/transmitter/manage.ps1
+++ b/services/transmitter/manage.ps1
@@ -34,7 +34,12 @@ function defaultfunc {
 }
 
 function build {
-  & docker build -t "$IMAGE_FULL_NAME" .
+  & cp -r "$script_dir/../../client/ayon_ftrack/common/" "$script_dir/ftrack_common"
+  try {
+    & docker build -t "$IMAGE_FULL_NAME" .
+  } finally {
+    & Remove-Item -Recurse -Force "$script_dir/ftrack_common"
+  }
 }
 
 function clean {
@@ -61,14 +66,19 @@ function load-env {
 
 function dev {
   load-env
-  & docker run --rm -ti `
-    -v "$($script_dir):/service" `
-  	--hostname ftrackproc `
-  	--env AYON_API_KEY=$env:AYON_API_KEY `
-  	--env AYON_SERVER_URL=$env:AYON_SERVER_URL `
-  	--env AYON_ADDON_NAME=ftrack `
-  	--env AYON_ADDON_VERSION=$ADDON_VERSION `
-  	"$($IMAGE_FULL_NAME)" python -m transmitter
+  & cp -r "$script_dir/../../client/ayon_ftrack/common/" "$script_dir/ftrack_common"
+  try {
+    & docker run --rm -ti `
+      -v "$($script_dir):/service" `
+      --hostname ftrackproc `
+      --env AYON_API_KEY=$env:AYON_API_KEY `
+      --env AYON_SERVER_URL=$env:AYON_SERVER_URL `
+      --env AYON_ADDON_NAME=ftrack `
+      --env AYON_ADDON_VERSION=$ADDON_VERSION `
+      "$IMAGE_FULL_NAME" python -m transmitter
+  } finally {
+    & Remove-Item -Recurse -Force "$script_dir/ftrack_common"
+  }
 }
 
 function bash {

--- a/services/transmitter/manage.ps1
+++ b/services/transmitter/manage.ps1
@@ -70,7 +70,7 @@ function dev {
   try {
     & docker run --rm -ti `
       -v "$($script_dir):/service" `
-      --hostname ftrackproc `
+      --hostname ftracktransmitter `
       --env AYON_API_KEY=$env:AYON_API_KEY `
       --env AYON_SERVER_URL=$env:AYON_SERVER_URL `
       --env AYON_ADDON_NAME=ftrack `


### PR DESCRIPTION
## Changelog Description
Copy ftrack common to docker image.

## Testing notes:
1. Built docker image contains `ftrack_common` so service can work.
