### PR TITLE
Services: Fix event summary

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -146,7 +146,7 @@ def create_session():
     }
     if tb_content is None:
         _GlobalContext.session_fail_logged = 2
-        event_data["summary"] = error_summary
+        event_data["summary"] = {"description": error_summary}
 
     else:
         _GlobalContext.session_fail_logged = 1

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -146,8 +146,6 @@ def create_session():
     }
     if tb_content is None:
         _GlobalContext.session_fail_logged = 2
-        event_data["summary"] = {"description": error_summary}
-
     else:
         _GlobalContext.session_fail_logged = 1
         event_data["payload"]["traceback"] = tb_content

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -128,8 +128,6 @@ def create_session():
     }
     if tb_content is None:
         _GlobalContext.session_fail_logged = 2
-        event_data["summary"] = {"description": error_summary}
-
     else:
         _GlobalContext.session_fail_logged = 1
         event_data["payload"]["traceback"] = tb_content

--- a/services/processor/processor/server.py
+++ b/services/processor/processor/server.py
@@ -128,7 +128,7 @@ def create_session():
     }
     if tb_content is None:
         _GlobalContext.session_fail_logged = 2
-        event_data["summary"] = error_summary
+        event_data["summary"] = {"description": error_summary}
 
     else:
         _GlobalContext.session_fail_logged = 1

--- a/services/transmitter/transmitter/service.py
+++ b/services/transmitter/transmitter/service.py
@@ -136,15 +136,13 @@ def create_session():
         "sender": ayon_api.ServiceContext.service_name,
         "finished": True,
         "store": True,
-        "description": "ftrack leecher error",
+        "description": "ftrack transmitter error",
         "payload": {
             "message": error_message,
         }
     }
     if tb_content is None:
         _GlobalContext.session_fail_logged = 2
-        event_data["summary"] = {"description": error_summary}
-
     else:
         _GlobalContext.session_fail_logged = 1
         event_data["payload"]["traceback"] = tb_content

--- a/services/transmitter/transmitter/service.py
+++ b/services/transmitter/transmitter/service.py
@@ -143,7 +143,7 @@ def create_session():
     }
     if tb_content is None:
         _GlobalContext.session_fail_logged = 2
-        event_data["summary"] = error_summary
+        event_data["summary"] = {"description": error_summary}
 
     else:
         _GlobalContext.session_fail_logged = 1


### PR DESCRIPTION
## Changelog Description
Don't set event summary in case of failed creation of ftrack session.

## Testing notes:
1. Set invalid server ftrack url in settings.
2. Run services.
3. They should crash and create event without any issues.
