### PR TITLE
Wepublisher: use service account to query secrets

### DIFF
--- a/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
+++ b/client/ayon_ftrack/plugins/publish/collect_webpublisher_credentials.py
@@ -39,8 +39,6 @@ class CollectWebpublisherCredentials(plugin.FtrackPublishContextPlugin):
     hosts = ["webpublisher", "photoshop"]
     targets = ["webpublish"]
 
-    service_user_name = ""
-
     def process(self, context):
         service_api_key, service_username = self._get_username_key(context)
         os.environ["FTRACK_API_USER"] = service_username
@@ -94,14 +92,13 @@ class CollectWebpublisherCredentials(plugin.FtrackPublishContextPlugin):
         username_secret = service_settings["username"]
 
         con = ayon_api.get_server_api_connection()
-        with con.as_username(self.service_user_name):
+        with con.as_username(None):
             secrets_by_name = {
                 secret["name"]: secret["value"]
                 for secret in ayon_api.get_secrets()
             }
         api_key = secrets_by_name.get(api_key_secret)
         username = secrets_by_name.get(username_secret)
-
         if not api_key or not username:
             raise KnownPublishError(
                 "Missing ftrack credentials in settings. "

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -66,6 +66,15 @@ class CollectFtrackCustomAttributeDataModel(BaseSettingsModel):
     )
 
 
+class CollectWebpublisherCredentialsModel(BaseSettingsModel):
+    _isGroup = True
+    enabled: bool = True
+    service_user_name: str = SettingsField(
+        title="Service user name",
+        description="User name with Webpublisher service was started with."
+    )
+
+
 class ValidateFtrackAttributesModel(BaseSettingsModel):
     _isGroup = True
     enabled: bool = True
@@ -308,6 +317,18 @@ class FtrackPublishPlugins(BaseSettingsModel):
             )
         )
     )
+    CollectWebpublisherCredentials: CollectWebpublisherCredentialsModel = (
+        SettingsField(
+            title="Collect Ftrack credentials for Webpublisher",
+            default_factory=CollectFtrackCustomAttributeDataModel,
+            description=(
+                "Translates user email to Ftrack user name to push to Ftrack "
+                "with correct username. \n"
+                "Applicable only for Webpublisher addon!"
+            )
+        )
+    )
+
     ValidateFtrackAttributes: ValidateFtrackAttributesModel = SettingsField(
         title="Validate ftrack Attributes",
         default_factory=ValidateFtrackAttributesModel,
@@ -526,6 +547,10 @@ DEFAULT_PUBLISH_SETTINGS = {
     "CollectFtrackCustomAttributeData": {
         "enabled": False,
         "custom_attribute_keys": []
+    },
+    "CollectWebpublisherCredentials": {
+        "enabled": True,
+        "service_user_name": "service"
     },
     "IntegrateHierarchyToFtrack": {
         "create_task_status_profiles": []

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -66,15 +66,6 @@ class CollectFtrackCustomAttributeDataModel(BaseSettingsModel):
     )
 
 
-class CollectWebpublisherCredentialsModel(BaseSettingsModel):
-    _isGroup = True
-    enabled: bool = True
-    service_user_name: str = SettingsField(
-        title="Service user name",
-        description="User name with Webpublisher service was started with."
-    )
-
-
 class ValidateFtrackAttributesModel(BaseSettingsModel):
     _isGroup = True
     enabled: bool = True
@@ -317,18 +308,6 @@ class FtrackPublishPlugins(BaseSettingsModel):
             )
         )
     )
-    CollectWebpublisherCredentials: CollectWebpublisherCredentialsModel = (
-        SettingsField(
-            title="Collect Ftrack credentials for Webpublisher",
-            default_factory=CollectFtrackCustomAttributeDataModel,
-            description=(
-                "Translates user email to Ftrack user name to push to Ftrack "
-                "with correct username. \n"
-                "Applicable only for Webpublisher addon!"
-            )
-        )
-    )
-
     ValidateFtrackAttributes: ValidateFtrackAttributesModel = SettingsField(
         title="Validate ftrack Attributes",
         default_factory=ValidateFtrackAttributesModel,
@@ -547,10 +526,6 @@ DEFAULT_PUBLISH_SETTINGS = {
     "CollectFtrackCustomAttributeData": {
         "enabled": False,
         "custom_attribute_keys": []
-    },
-    "CollectWebpublisherCredentials": {
-        "enabled": True,
-        "service_user_name": "service"
     },
     "IntegrateHierarchyToFtrack": {
         "create_task_status_profiles": []


### PR DESCRIPTION
## Changelog Description
Previous implementation was using regular (current) AYON account which failed for non admin accounts (`artist`, `freelancer`).
This uses wrapper for service account which is used to start ASH worker.


## Testing notes:
2. publish in WP
