### PR TITLE
Collect ftrack family defaults

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -421,7 +421,8 @@ DEFAULT_PUBLISH_SETTINGS = {
                     "animation",
                     "look",
                     "rig",
-                    "camera"
+                    "camera",
+                    "review"
                 ],
                 "task_types": [],
                 "task_names": [],

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -431,6 +431,25 @@ DEFAULT_PUBLISH_SETTINGS = {
             },
             {
                 "host_names": [
+                    "blender",
+                    "houdini",
+                    "max"
+                ],
+                "product_types": [],
+                "task_types": [],
+                "task_names": [],
+                "add_ftrack_family": False,
+                "advanced_filtering": [
+                    {
+                        "families": [
+                            "review"
+                        ],
+                        "add_ftrack_family": True
+                    }
+                ]
+            },
+            {
+                "host_names": [
                     "tvpaint"
                 ],
                 "product_types": [
@@ -492,18 +511,6 @@ DEFAULT_PUBLISH_SETTINGS = {
                 "product_types": [
                     "plate",
                     "take"
-                ],
-                "task_types": [],
-                "task_names": [],
-                "add_ftrack_family": True,
-                "advanced_filtering": []
-            },
-            {
-                "host_names": [
-                    "houdini"
-                ],
-                "product_types": [
-                    "usd"
                 ],
                 "task_types": [],
                 "task_names": [],

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -28,7 +28,7 @@ class CollectFamilyProfile(BaseSettingsModel):
     )
     product_types: list[str] = SettingsField(
         default_factory=list,
-        title="Families",
+        title="Product types",
     )
     task_types: list[str] = SettingsField(
         default_factory=list,


### PR DESCRIPTION
## Changelog Description
Add `review` product type to maya product types. Added simple houdni, blender and 3ds max collection if instnces have review family.

## Testing notes:
1. Maya `review` product type is integrated to ftrack.
2. Instances with review family from houdini, blender and 3ds max are integrated to ftrack.

Resolves https://github.com/ynput/ayon-ftrack/issues/193