### PR TITLE
Chore: Define package mode in services pyproject toml

### DIFF
--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -3,6 +3,7 @@ name = "ftrack-leecher"
 version = "1.3.3+dev"
 description = ""
 authors = ["Ynput s.r.o. <info@ynput.io>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.10"

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -3,6 +3,7 @@ name = "ftrack-processor"
 version = "1.3.3+dev"
 description = ""
 authors = ["Ynput s.r.o. <info@ynput.io>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.10"

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -3,6 +3,7 @@ name = "ftrack-transmitter"
 version = "1.3.3+dev"
 description = ""
 authors = ["Ynput s.r.o. <info@ynput.io>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.10"


### PR DESCRIPTION
## Changelog Description
Define package mode in services pyproject.toml for newer peotry release.

## Testing notes:
1. It is possible to build service docker images.
