### PR TITLE
Chore: Stop using 'six'

### DIFF
--- a/client/ayon_ftrack/common/lib.py
+++ b/client/ayon_ftrack/common/lib.py
@@ -2,7 +2,6 @@ import re
 import numbers
 import socket
 
-import six
 from ayon_api import (
     get_base_url,
     get_service_addon_name,
@@ -81,13 +80,11 @@ def create_chunks(iterable, chunk_size=None):
     return chunks
 
 
-def is_string_number(value):
+def is_string_number(value: str) -> bool:
     """Can string value be converted to number (float)."""
 
-    if not isinstance(value, six.string_types):
-        raise TypeError("Expected {} got {}".format(
-            ", ".join(str(t) for t in six.string_types), str(type(value))
-        ))
+    if not isinstance(value, str):
+        raise TypeError(f"Expected str got {str(type(value))}")
     if value == ".":
         return False
 

--- a/client/ayon_ftrack/common/lib.py
+++ b/client/ayon_ftrack/common/lib.py
@@ -133,7 +133,7 @@ def convert_to_fps(source_value):
         InvalidFpsValue: When value can't be converted to float.
     """
 
-    if not isinstance(source_value, six.string_types):
+    if not isinstance(source_value, str):
         if isinstance(source_value, numbers.Number):
             return float(source_value)
         return source_value

--- a/client/ayon_ftrack/plugins/_unused_publish/integrate_ftrack_comments.py
+++ b/client/ayon_ftrack/plugins/_unused_publish/integrate_ftrack_comments.py
@@ -1,6 +1,4 @@
-import sys
 import pyblish.api
-import six
 
 
 class IntegrateFtrackComments(pyblish.api.InstancePlugin):
@@ -26,7 +24,6 @@ class IntegrateFtrackComments(pyblish.api.InstancePlugin):
 
         try:
             session.commit()
-        except Exception:
-            tp, value, tb = sys.exc_info()
+        except Exception as exc:
             session.rollback()
-            six.reraise(tp, value, tb)
+            raise exc

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
@@ -5,7 +5,6 @@ Requires:
     instance > ftrackIntegratedAssetVersionsData
 """
 
-import sys
 import json
 
 import pyblish.api

--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_description.py
@@ -8,7 +8,6 @@ Requires:
 import sys
 import json
 
-import six
 import pyblish.api
 from ayon_core.lib import StringTemplate
 
@@ -108,8 +107,7 @@ class IntegrateFtrackDescription(plugin.FtrackPublishInstancePlugin):
                 self.log.debug("Comment added to AssetVersion \"{}\"".format(
                     str(asset_version)
                 ))
-            except Exception:
-                tp, value, tb = sys.exc_info()
+            except Exception as exc:
                 session.rollback()
                 session._configure_locations()
-                six.reraise(tp, value, tb)
+                raise exc

--- a/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -1,8 +1,6 @@
-import sys
 import collections
 from copy import deepcopy
 
-import six
 import pyblish.api
 import ayon_api
 
@@ -350,11 +348,10 @@ class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
             if session.recorded_operations:
                 try:
                     session.commit()
-                except Exception:
-                    tp, value, tb = sys.exc_info()
+                except Exception as exc:
                     session.rollback()
                     session._configure_locations()
-                    six.reraise(tp, value, tb)
+                    raise exc
 
             # TASKS
             instances_by_task_name = collections.defaultdict(list)
@@ -399,11 +396,10 @@ class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
             self.create_links(session, project_name, entity_data, entity)
             try:
                 session.commit()
-            except Exception:
-                tp, value, tb = sys.exc_info()
+            except Exception as exc:
                 session.rollback()
                 session._configure_locations()
-                six.reraise(tp, value, tb)
+                raise exc
 
             # Create notes.
             entity_comments = entity_data.get("comments")
@@ -413,11 +409,10 @@ class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
 
                 try:
                     session.commit()
-                except Exception:
-                    tp, value, tb = sys.exc_info()
+                except Exception as exc:
                     session.rollback()
                     session._configure_locations()
-                    six.reraise(tp, value, tb)
+                    raise exc
 
             # Import children.
             children = entity_data.get("children")
@@ -439,11 +434,10 @@ class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
             session.delete(link)
             try:
                 session.commit()
-            except Exception:
-                tp, value, tb = sys.exc_info()
+            except Exception as exc:
                 session.rollback()
                 session._configure_locations()
-                six.reraise(tp, value, tb)
+                raise exc
 
         # Create new links.
         input_folder_ids = {
@@ -541,11 +535,10 @@ class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
 
         try:
             session.commit()
-        except Exception:
-            tp, value, tb = sys.exc_info()
+        except Exception as exc:
             session.rollback()
             session._configure_locations()
-            six.reraise(tp, value, tb)
+            raise exc
 
         if status_id is not None:
             ftrack_status_by_task_id[task["id"]] = None


### PR DESCRIPTION
## Changelog Description
Removed usage of `six` python module.

## Additional review information
We don't support python 2 anymore so we can stop using `six`.

## Testing notes:
1. Everything should work as before.
