### PR TITLE
Transmitter: Use correct status field from workflow

### DIFF
--- a/services/transmitter/transmitter/logic.py
+++ b/services/transmitter/transmitter/logic.py
@@ -690,8 +690,8 @@ class EventProcessor:
                 f" where workflow_schema_id is '{av_workflow_schema_id}'"
             ).all()
             return {
-                status["id"]
-                for status in workflow_statuses
+                workflow["status_id"]
+                for workflow in workflow_statuses
             }
 
         if is_folder:


### PR DESCRIPTION
## Changelog Description
Version workflows are synchronized correctly.

## Additional review information
Using correct key from workflow `status_id` instead of workflow's `id`.

## Testing notes:
1. Version workflows in ftrack don't cause issues with sync AYON to ftrack.
