### PR TITLE
Integrate hierarchy: Add missing argument

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -181,7 +181,7 @@ class IntegrateHierarchyToFtrack(plugin.FtrackPublishContextPlugin):
         ft_task_types = self.get_all_task_types(ft_project)
         ft_task_statuses = self.get_task_statuses(ft_project)
         project_settings = context.data["project_settings"]
-        attr_confs = get_all_attr_configs()
+        attr_confs = get_all_attr_configs(session)
         attrs_mapping = get_custom_attributes_mapping(
             session, project_settings["ftrack"], attr_confs
         )


### PR DESCRIPTION
## Changelog Description
Pass in missing argument to `get_all_attr_configs` in integrate hierarchy publish plugin.

## Traceback
![image](https://github.com/user-attachments/assets/6c03d309-2685-4926-86e5-dd5e774adb2d)


## Testing notes:
1. Run editorial publishing, it should create entities or update attributes on entities.
2. It should work just fine.
