### PR TITLE
Chore: Make settings model classes unique

### DIFF
--- a/server/settings/desktopapp_handlers.py
+++ b/server/settings/desktopapp_handlers.py
@@ -9,7 +9,7 @@ from ayon_server.settings import (
 from .common import DictWithStrList, ROLES_TITLE
 
 
-class SimpleAction(BaseSettingsModel):
+class SimpleLocalAction(BaseSettingsModel):
     enabled: bool = True
     role_list: list[str] = SettingsField(
         title=ROLES_TITLE,
@@ -47,7 +47,7 @@ class CreateUpdateCustomAttributesAction(BaseSettingsModel):
     )
 
 
-class PrepareProjectAction(SimpleAction):
+class PrepareProjectAction(SimpleLocalAction):
     create_project_structure_checked: bool = SettingsField(
         True,
         description="Check \"Create project structure\" by default",
@@ -84,21 +84,21 @@ class FtrackDesktopAppHandlers(BaseSettingsModel):
         title="Prepare Project",
         default_factory=PrepareProjectAction,
     )
-    clean_hierarchical_attr: SimpleAction = SettingsField(
+    clean_hierarchical_attr: SimpleLocalAction = SettingsField(
         title="Clean hierarchical custom attributes",
-        default_factory=SimpleAction
+        default_factory=SimpleLocalAction
     )
-    delete_old_versions: SimpleAction = SettingsField(
+    delete_old_versions: SimpleLocalAction = SettingsField(
         title="Delete old versions",
-        default_factory=SimpleAction,
+        default_factory=SimpleLocalAction,
     )
-    delivery_action: SimpleAction = SettingsField(
+    delivery_action: SimpleLocalAction = SettingsField(
         title="Delivery action",
-        default_factory=SimpleAction,
+        default_factory=SimpleLocalAction,
     )
-    job_killer: SimpleAction = SettingsField(
+    job_killer: SimpleLocalAction = SettingsField(
         title="Job Killer",
-        default_factory=SimpleAction,
+        default_factory=SimpleLocalAction,
     )
     fill_workfile_attribute: FillWorkfileAttr = SettingsField(
         title="Fill workfile Custom attribute",

--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -10,7 +10,7 @@ from ayon_server.settings import (
 from .common import DictWithStrList, ROLES_TITLE
 
 
-class SimpleAction(BaseSettingsModel):
+class SimpleServiceAction(BaseSettingsModel):
     enabled: bool = True
     role_list: list[str] = SettingsField(
         title=ROLES_TITLE,
@@ -322,17 +322,17 @@ class ComponentsSizeCalcModel(BaseSettingsModel):
 class FtrackServiceHandlers(BaseSettingsModel):
     """Settings for event handlers running in ftrack service."""
 
-    prepare_project: SimpleAction = SettingsField(
+    prepare_project: SimpleServiceAction = SettingsField(
         title="Prepare Project",
-        default_factory=SimpleAction,
+        default_factory=SimpleServiceAction,
     )
-    sync_from_ftrack: SimpleAction = SettingsField(
+    sync_from_ftrack: SimpleServiceAction = SettingsField(
         title="Sync to AYON",
-        default_factory=SimpleAction,
+        default_factory=SimpleServiceAction,
     )
-    sync_users_from_ftrack: SimpleAction = SettingsField(
+    sync_users_from_ftrack: SimpleServiceAction = SettingsField(
         title="Sync Users to AYON",
-        default_factory=SimpleAction,
+        default_factory=SimpleServiceAction,
     )
     sync_hier_entity_attributes: SyncHierarchicalAttributes = SettingsField(
         title="Sync Hierarchical and Entity Attributes",
@@ -342,9 +342,9 @@ class FtrackServiceHandlers(BaseSettingsModel):
         title="Clone Review Session",
         default_factory=CloneReviewAction,
     )
-    delete_ayon_entities: SimpleAction = SettingsField(
+    delete_ayon_entities: SimpleServiceAction = SettingsField(
         title="Delete Folders/Products",
-        default_factory=SimpleAction,
+        default_factory=SimpleServiceAction,
     )
     thumbnail_updates: ThumbnailHierarchyUpdates = SettingsField(
         title="Update Hierarchy thumbnails",


### PR DESCRIPTION
## Changelog Description
Renamed `SimpleAction` to `SimpleLocalAction` and `SimpleServiceAction` to make the class names unique.

## Additional review information
Pydantic requires to have unique class names for scheme generation, luckily both models have currently same structure so it did not cause any issues.