### PR TITLE
To AYON sync: Reverse order of project statuses on sync

### DIFF
--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -303,7 +303,7 @@ class SyncFromFtrack:
                 "scope": scope,
                 "sort": status["sort"],
             })
-        statuses_data.sort(key=lambda i: i["sort"])
+        statuses_data.sort(key=lambda i: i["sort"], reverse=True)
 
         statuses = self._entity_hub.project_entity.statuses
         for idx, status_data in enumerate(statuses_data):


### PR DESCRIPTION
## Changelog Description
Reverse order of project statuses on sync to AYON.

## Additional review information
The sort value used to sort statuses is not from first to last, but from last to first. Or rather, higher value goes first.

## Testing notes:
1. Start leecher and processor services.
2. Sync project.
3. Order of statuses in ftrack should match order of statuses in AYON.

Resolves https://github.com/ynput/ayon-tvpaint/issues/29
