### PR TITLE
Application actions: Fix applications icon

### DIFF
--- a/client/ayon_ftrack/event_handlers_user/action_applications.py
+++ b/client/ayon_ftrack/event_handlers_user/action_applications.py
@@ -231,7 +231,7 @@ class AppplicationsAction(BaseAction):
         if not icon:
             return icon
 
-        if icon in self._icons_mapping:
+        if icon not in self._icons_mapping:
             # ftrack frontend does not allow redirect to IP address, but
             #   allows redirect to 'localhost'
             result = urlparse(icon)


### PR DESCRIPTION
## Changelog Description
Use `localhost` instead of IP address for application icon.

## Additional review information
Frontend of ftrack actions menu does not consider IP address as safe source for icons, but localhost is considered as safe. Modified the app icon to use `localhost` if IP address is `127.0.01`.

## Testing notes:
1. Make sure you use these changes in AYON launcher (dev mode, or create package).
2. Show actions on task.
3. Applications actions should show icons.

Resolves https://github.com/ynput/ayon-ftrack/issues/212
Resolves https://github.com/ynput/ayon-ftrack/issues/213