### PR TITLE
Chore: Lower ftrack and capitalize AYON in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [project]
 name = "ayon-ftrack"
 version = "1.4.3"
-description = "Ftrack addon for Ayon.\n"
+description = "ftrack addon for AYON.\n"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Changelog Description
Fix letters in pyproject.toml description.

## Additional review information
AYON is meant to be used as `AYON` and ftrack is meant to be used as `ftrack`.
