### PR TITLE
Settings: Use 'conditional_enum' instead of 'conditionalEnum'

### DIFF
--- a/server/settings/custom_attributes.py
+++ b/server/settings/custom_attributes.py
@@ -14,7 +14,7 @@ class CustomAttributeMappingModel(BaseSettingsModel):
         "hierarchical",
         title="Attribute type",
         enum_resolver=_attr_types,
-        conditionalEnum=True,
+        conditional_enum=True,
     )
     hierarchical: str = SettingsField(
         "",

--- a/server/settings/service_handlers.py
+++ b/server/settings/service_handlers.py
@@ -217,7 +217,7 @@ class DailyListCustomAttributesModel(BaseSettingsModel):
         "bool_value",
         title="Attribute type",
         enum_resolver=custom_attribute_type,
-        conditionalEnum=True,
+        conditional_enum=True,
     )
     bool_value: bool = SettingsField(True, title="Expected value")
     str_value: str = SettingsField("", title="Expected value")


### PR DESCRIPTION
## Changelog Description
Use `conditional_enum` instead of `conditionalEnum` which is deprecated.

## Testing notes:
1. Settings still do work.
