### PR TITLE
Chore: Smaller docker images

### DIFF
--- a/services/leecher/Dockerfile
+++ b/services/leecher/Dockerfile
@@ -1,17 +1,11 @@
-FROM python:3.9-bullseye
+FROM python:3.9-alpine
 ENV PYTHONUNBUFFERED=1
-
-RUN apt-get update \
-  && apt-get install -y curl python3-pip python3-virtualenv \
-  && pip install poetry
 
 RUN mkdir /service
 COPY ./leecher /service/leecher
 COPY ./pyproject.toml /service/pyproject.toml
 WORKDIR /service
 
-
-RUN poetry config virtualenvs.create false \
- && poetry install --no-interaction --no-ansi
+RUN pip install .
 
 CMD ["python", "-m", "leecher"]

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -1,18 +1,9 @@
-[tool.poetry]
+[project]
 name = "ftrack-leecher"
 version = "1.4.5+dev"
 description = ""
-authors = ["Ynput s.r.o. <info@ynput.io>"]
-package-mode = false
-
-[tool.poetry.dependencies]
-python = ">=3.9,<3.10"
-ayon-python-api = "1.0.11"
-ftrack-python-api = "2.3.3"
-
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
+dependencies = [
+    "ayon-python-api==1.0.11",
+    "ftrack-python-api==2.3.3"
+]

--- a/services/processor/Dockerfile
+++ b/services/processor/Dockerfile
@@ -1,9 +1,5 @@
-FROM python:3.9-bullseye
+FROM python:3.9-alpine
 ENV PYTHONUNBUFFERED=1
-
-RUN apt-get update \
-  && apt-get install -y curl python3-pip python3-virtualenv \
-  && pip install poetry
 
 RUN mkdir /service
 COPY ./processor /service/processor
@@ -11,8 +7,6 @@ COPY ./ftrack_common /service/ftrack_common
 COPY ./pyproject.toml /service/pyproject.toml
 WORKDIR /service
 
-
-RUN poetry config virtualenvs.create false \
- && poetry install --no-interaction --no-ansi
+RUN pip install .
 
 CMD ["python", "-m", "processor"]

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -1,19 +1,13 @@
-[tool.poetry]
+[project]
 name = "ftrack-processor"
 version = "1.4.5+dev"
 description = ""
-authors = ["Ynput s.r.o. <info@ynput.io>"]
-package-mode = false
+authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
+dependencies = [
+    "platformdirs",
+    "ayon-python-api==1.0.11",
+    "ftrack-python-api==2.3.3"
+]
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.10"
-ayon-python-api = "1.0.11"
-ftrack-python-api = "2.3.3"
-platformdirs = "*"
-
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.setuptools]
+py-modules = ["processor", "ftrack_common"]

--- a/services/transmitter/Dockerfile
+++ b/services/transmitter/Dockerfile
@@ -1,9 +1,5 @@
-FROM python:3.9-bullseye
+FROM python:3.9-alpine
 ENV PYTHONUNBUFFERED=1
-
-RUN apt-get update \
-  && apt-get install -y curl python3-pip python3-virtualenv \
-  && pip install poetry
 
 RUN mkdir /service
 COPY ./transmitter /service/transmitter
@@ -11,8 +7,6 @@ COPY ./ftrack_common /service/ftrack_common
 COPY ./pyproject.toml /service/pyproject.toml
 WORKDIR /service
 
-
-RUN poetry config virtualenvs.create false \
- && poetry install --no-interaction --no-ansi
+RUN pip install .
 
 CMD ["python", "-m", "transmitter"]

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -1,18 +1,12 @@
-[tool.poetry]
+[project]
 name = "ftrack-transmitter"
 version = "1.4.5+dev"
 description = ""
-authors = ["Ynput s.r.o. <info@ynput.io>"]
-package-mode = false
+authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
+dependencies = [
+    "ayon-python-api==1.0.11",
+    "ftrack-python-api==2.3.3"
+]
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.10"
-ayon-python-api = "1.0.11"
-ftrack-python-api = "2.3.3"
-
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.setuptools]
+py-modules = ["transmitter", "ftrack_common"]


### PR DESCRIPTION
## Changelog Description
Use alpine docker image and don't use poetry for installing dependencies inside the image.

## Additional review information
It looks like the images are working as before but have at about 80mb.

## Testing notes:
1. Change version in package.py to 1.4.6-dev .
2. Run `create_package.py`.
3. Create all services using `manage.ps1 build`.
4. Upload package to server.
5. Create all 3 services in AYON server.
6. ASH should start them and they should work.
7. The size of images is a lot smaller.