### PR TITLE
Avoid comment being removed as AssetVersion description in farm submi…

### DIFF
--- a/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/client/ayon_ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -130,7 +130,7 @@ class IntegrateFtrackInstance(plugin.FtrackPublishInstancePlugin):
             },
             "assetversion_data": {
                 "version": version_number,
-                "comment": instance.context.data.get("comment") or "",
+                "comment": instance.data.get("comment") or "",
                 "status_name": status_name,
                 "custom_attributes": av_custom_attributes
             },


### PR DESCRIPTION
## Changelog Description

This PR fixes issue #242. 

Introduced comment remains as AssetVersion's description for both local and farm publishes.

## Additional review information

On farm submissions, `instance.context.data["comment"]` remained empty despite a comment being introduced. This later made the following [lines](https://github.com/ynput/ayon-ftrack/blob/618e39bca39f39d9aaa6413458b5e568ae2563b9/client/ayon_ftrack/plugins/publish/integrate_ftrack_api.py#L372-L384) in `integrate_ftrack_api` to override AssetVersion description to `""`.
 

## Testing notes:
1. Launch Nuke and submit to the farm (introduce a comment in the publisher UI)
2. Check AssetVersion in ftrack, it should have what got introduced as a comment in the description. 
3. Check AssetVersion again once publish process finishes, description remains.

Resolves https://github.com/ynput/ayon-ftrack/issues/242