### PR TITLE
Actions: Clean hierarchical attributes fix show message call

### DIFF
--- a/client/ayon_ftrack/event_handlers_user/action_clean_hierarchical_attributes.py
+++ b/client/ayon_ftrack/event_handlers_user/action_clean_hierarchical_attributes.py
@@ -31,7 +31,7 @@ class CleanHierarchicalAttrsAction(LocalAction):
         project_id = entities[0]["id"]
 
         user_message = "This may take some time"
-        self.show_message(event, user_message, result=True)
+        self.show_message(event, user_message, True)
         self.log.debug("Preparing entities for cleanup.")
 
         all_entities = session.query(


### PR DESCRIPTION
## Changelog Description
Fix arguments passed to `show_message`.

## Additional review information
It uses `result=True` for some reason (which should be `success=True`). Removed the kwargs and use positional arguments.

## Testing notes:
1. Clean Hierarchical attributes action works.
