### PR TITLE
Process preparation: Proper check for addon enabled state

### DIFF
--- a/client/ayon_ftrack/common/lib.py
+++ b/client/ayon_ftrack/common/lib.py
@@ -27,7 +27,11 @@ def is_ftrack_enabled_in_settings(project_settings):
 
     Returns:
         bool: True if ftrack is enabled in project settings.
+
     """
+    # Allow to pass full project settings.
+    if "ftrack" in project_settings:
+        project_settings = project_settings["ftrack"]
 
     ftrack_enabled = project_settings.get("enabled")
     # If 'ftrack_enabled' is not set, we assume it is enabled.

--- a/client/ayon_ftrack/ftrack_addon.py
+++ b/client/ayon_ftrack/ftrack_addon.py
@@ -210,7 +210,7 @@ class FtrackAddon(
         else:
             settings = get_studio_settings()
 
-        if not is_ftrack_enabled_in_settings(settings):
+        if not is_ftrack_enabled_in_settings(settings["ftrack"]):
             return
 
         # Not sure if this should crash or silently continue?


### PR DESCRIPTION
## Changelog Description
Pass ftrack settings to `is_ftrack_enabled_in_settings`.

## Additional review information
Also added option to pass full settings dictionary to `is_ftrack_enabled_in_settings` function to avoid these complications.

## Testing notes:
1. Disable ftrack addon in ftrack settings.
2. Logout from ftrack in tray (if you're logged in).
3. Start an application.
4. It should not ask for ftrack credentials.

Resolves https://github.com/ynput/ayon-ftrack/issues/258