### PR TITLE
Services: Sync heap issues

### DIFF
--- a/service_tools/pyproject.toml
+++ b/service_tools/pyproject.toml
@@ -5,6 +5,6 @@ description = "Tools for developing/testing ftrack services"
 authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
 requires-python = ">=3.11"
 dependencies = [
-    "ayon-python-api>=1.2.14",
+    "ayon-python-api>=1.2.20",
     "ftrack-python-api>=3.1.0"
 ]

--- a/service_tools/uv.lock
+++ b/service_tools/uv.lock
@@ -29,15 +29,15 @@ wheels = [
 
 [[package]]
 name = "ayon-python-api"
-version = "1.2.16"
+version = "1.2.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "unidecode" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/b9/a3d96adb6297e40e83f727adf544d2fc17a3b05805158f2d5df578c6deb8/ayon_python_api-1.2.16.tar.gz", hash = "sha256:43a643d5c45b0c01e340670b2703f60567efbb38b8835267c35511f6578079f1", size = 170537, upload-time = "2026-04-07T09:35:11.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/dd/72dc5457fed00ae13465857becc96ac72bc599990c38701e4c6573b2409e/ayon_python_api-1.2.20.tar.gz", hash = "sha256:2a2768e1d7a3a49b63f5c5a9f005ede89937b44cd70836aff77c3f61b0f5b37b", size = 174479, upload-time = "2026-05-26T09:49:02.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/2e/453ae59d534961d2dd24934339a863ee0c110afac593cf3898c8a47b1e4d/ayon_python_api-1.2.16-py3-none-any.whl", hash = "sha256:19e5279948d6d438a248106e8a25619e822f84a60f29e3c1154b4865639e6008", size = 170242, upload-time = "2026-04-07T09:35:09.771Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b8/0039f2dfe1307942a159b9f443a3fdb26ddc4db7e7ed3bce7ad7c5f8881b/ayon_python_api-1.2.20-py3-none-any.whl", hash = "sha256:1e9b9730240014e03d66528b4e1a7c39857eceed8abfb84b17a5d70cde26fa1b", size = 173736, upload-time = "2026-05-26T09:49:01.811Z" },
 ]
 
 [[package]]
@@ -202,7 +202,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ayon-python-api", specifier = ">=1.2.14" },
+    { name = "ayon-python-api", specifier = ">=1.2.20" },
     { name = "ftrack-python-api", specifier = ">=3.1.0" },
 ]
 

--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -15,6 +15,11 @@ IGNORE_TOPICS = {
     "ftrack.meta.connected",
     "ftrack.meta.disconnected",
 }
+IGNORED_ENTITY_TYPES = {
+    "socialfeed",
+    "socialnotification",
+    "team",
+}
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +36,18 @@ def callback(event):
         return
 
     event_data = event._data
+    event_entities = event_data["data"].get("entities") or []
+    # Allow custom events
+    is_valid = True
+    # Check if there is at least one entity with non-ignored type.
+    for entity in event_entities:
+        is_valid = entity["entityType"] not in IGNORED_ENTITY_TYPES
+        if is_valid:
+            break
+
+    if not is_valid:
+        return
+
     description = create_event_description(event_data)
 
     try:

--- a/services/leecher/pyproject.toml
+++ b/services/leecher/pyproject.toml
@@ -4,6 +4,6 @@ version = "1.6.1+dev"
 description = ""
 authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
 dependencies = [
-    "ayon-python-api==1.2.16",
+    "ayon-python-api==1.2.20",
     "ftrack-python-api==3.1.0"
 ]

--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -1170,7 +1170,7 @@ class SyncFromFtrack:
                 if ayon_user:
                     new_assignees.add(ayon_user)
 
-            ayon_task.assignees = list(new_assignees)
+            ayon_task.assignees = new_assignees
 
     def update_attributes_from_ftrack(
         self,

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
 dependencies = [
     "platformdirs",
-    "ayon-python-api==1.2.16",
+    "ayon-python-api==1.2.20",
     "ftrack-python-api==3.1.0"
 ]
 

--- a/services/transmitter/pyproject.toml
+++ b/services/transmitter/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.6.1+dev"
 description = ""
 authors = [{name = "Ynput s.r.o.", email ="info@ynput.io"}]
 dependencies = [
-    "ayon-python-api==1.2.16",
+    "ayon-python-api==1.2.20",
     "ftrack-python-api==3.1.0"
 ]
 


### PR DESCRIPTION
## Changelog Description
Updated ayon api with version that does use assignees as set instead of list. Ignore socialfeed, socialnotification and team entity type events in leecher.

## Additional review information
Try to solve few CPU heap issues of AYON server with changes in services. Entity types `socialfeed`, `socialnotification` and `team` are not used for any known event handler so they can be 100% skipped. They are connected to notifications in frontend which does not have to be handled by services.

## Testing notes:
1. ftrack services should cause less events and trigger less changes related to assignees.

Resolves https://github.com/ynput/ayon-ftrack/issues/270