### PR TITLE
Sync of list: Add only version ids that do exist in AYON

### DIFF
--- a/services/processor/processor/lib/sync_from_ftrack.py
+++ b/services/processor/processor/lib/sync_from_ftrack.py
@@ -1878,6 +1878,17 @@ class SyncFromFtrack:
             if entity and entity.entity_type == list_type:
                 to_add.add(ay_id)
 
+        # Make sure the versions do exist
+        if list_type == "version":
+            to_add = {
+                version["id"]
+                for version in ayon_api.get_versions(
+                    self.project_name,
+                    version_ids=to_add,
+                    fields={"id"},
+                )
+            }
+
         if ayon_list:
             for item in ayon_list["items"]:
                 entity_id = item["entityId"]


### PR DESCRIPTION
## Changelog Description
Do not add versions ids that don't exist in AYON.

## Additional review information
Version in ftrack may contain filled AYON id of version that doesn't exist in AYON anymore (for whateever reason). This PR adds filtering of the versions to add to the list.

## Testing notes:
1. Fill AYON id on a ftrack version to id that doesn't exist in ayon.
2. Sync the project.
3. It should just skip that item and sync everything else.
